### PR TITLE
Fixed Bugs on calculating 'theHostClockFrequency'

### DIFF
--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -574,7 +574,7 @@ OSStatus ProxyAudioDevice::Initialize(AudioServerPlugInDriverRef inDriver, Audio
     //    calculate the host ticks per frame
     struct mach_timebase_info theTimeBaseInfo;
     mach_timebase_info(&theTimeBaseInfo);
-    Float64 theHostClockFrequency = theTimeBaseInfo.denom / theTimeBaseInfo.numer;
+    Float64 theHostClockFrequency = (Float64)theTimeBaseInfo.denom / theTimeBaseInfo.numer;
     theHostClockFrequency *= 1000000000.0;
     gDevice_HostTicksPerFrame = theHostClockFrequency / gDevice_SampleRate;
 
@@ -734,7 +734,7 @@ OSStatus ProxyAudioDevice::PerformDeviceConfigurationChange(AudioServerPlugInDri
 
         //    recalculate the state that depends on the sample rate
         mach_timebase_info(&theTimeBaseInfo);
-        theHostClockFrequency = theTimeBaseInfo.denom / theTimeBaseInfo.numer;
+        theHostClockFrequency = (Float64)theTimeBaseInfo.denom / theTimeBaseInfo.numer;
         theHostClockFrequency *= 1000000000.0;
         gDevice_HostTicksPerFrame = theHostClockFrequency / gDevice_SampleRate;
     }


### PR DESCRIPTION
"theTimeBaseInfo.denom / theTimeBaseInfo.numer" dividing operation in Apple Silicon will get 0 on apple silicon

The below code have different behavior on Intel CPU types and apple Silicon CPU types.
`#import <Foundation/Foundation.h>
#import <mach/mach_time.h>

int main(int argc, const char * argv[]) {
	@autoreleasepool {
	    // insert code here...
		struct mach_timebase_info theTimeBaseInfo;
		mach_timebase_info(&theTimeBaseInfo);
		Float64 theHostClockFrequency = theTimeBaseInfo.denom / theTimeBaseInfo.numer;
		theHostClockFrequency *= 1000000000.0;
		NSLog(@"%f", theHostClockFrequency);
	}
	return 0;
}
`

So we should cast the theTimeBaseInfo.denom into Float64 first. Otherwise a theHostClockFrequency will result in no sound from PAD.