### PR TITLE
Adds Homebrew pkg, promote packages above manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Proxy Audio Driver
 
-A HAL virtual audio driver for macOS that sends all output to another audio device. It's main purpose is to make it possible to use macOS's system volume controls such as the volume menu bar icon or volume keyboard keys to change the volume of external audio interfaces that don't allow it. It might be useful for something else too.
+A HAL virtual audio driver for macOS that sends all output to another audio device. Its main purpose is to make it possible to use macOS's system volume controls, such as the volume menu bar icon or volume keyboard keys, to change the volume of external audio interfaces that don't allow it. It might be useful for something else, too.
 
 ### Installation
 
@@ -8,16 +8,18 @@ A HAL virtual audio driver for macOS that sends all output to another audio devi
 
 [![Packaging status on repology](https://repology.org/badge/vertical-allrepos/proxy-audio-device.svg)](https://repology.org/project/proxy-audio-device/versions)
 
-Install [proxy-audio-device with Homebrew with `brew`](https://formulae.brew.sh/cask/proxy-audio-device)
-_or_ [proxy-audio-device on macports with `port`](https://ports.macports.org/port/proxy-audio-device/):
+Install [proxy-audio-device with Homebrew with `brew`](https://formulae.brew.sh/cask/proxy-audio-device):
 
     brew install --cask proxy-audio-device
+
+_or_ [proxy-audio-device on macports with `port`](https://ports.macports.org/port/proxy-audio-device/):
+
     sudo port install proxy-audio-device
 
-2. Run Proxy Audio Device Settings app to configure your new audio device.
-
+Run the _Proxy Audio Device Settings_ app to configure your new audio device.
 
 #### Manual installation
+
 1. Download the latest release from this GitHub repository
 
 2. Create the directory `HAL` if it does not exist. Open a terminal window, execute the following command and enter your administrator password when prompted:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ A HAL virtual audio driver for macOS that sends all output to another audio devi
 
 ### Installation
 
+#### Install with a package manager
+
+[![homebrew cask](https://img.shields.io/homebrew/cask/v/proxy-audio-device)](https://formulae.brew.sh/cask/proxy-audio-device)
+[![macports](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fports.macports.org%2Fapi%2Fv1%2Fports%2Fproxy-audio-device%2F&query=%24.version&label=macports)](https://ports.macports.org/port/proxy-audio-device/)
+
+Install [proxy-audio-device with Homebrew with `brew`](https://formulae.brew.sh/cask/proxy-audio-device)
+_or_ [proxy-audio-device on macports with `port`](https://ports.macports.org/port/proxy-audio-device/):
+
+    brew install --cask proxy-audio-device
+    sudo port install proxy-audio-device
+
+2. Run Proxy Audio Device Settings app to configure your new audio device.
+
+
 #### Manual installation
 1. Download the latest release from this GitHub repository
 
@@ -21,13 +35,6 @@ A HAL virtual audio driver for macOS that sends all output to another audio devi
         sudo launchctl kickstart -k system/com.apple.audio.coreaudiod
 
 5. Run Proxy Audio Device Settings to configure the proxy output device's name, which output device the driver will proxy to, and how large you want its audio buffer to be.
-
-#### Install with macports
-1. Install proxy-audio-device
-
-        sudo port install proxy-audio-device
-
-2. Run Proxy Audio Device Settings app to configure your new audio device.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ A HAL virtual audio driver for macOS that sends all output to another audio devi
 
 #### Install with a package manager
 
-[![homebrew cask](https://img.shields.io/homebrew/cask/v/proxy-audio-device)](https://formulae.brew.sh/cask/proxy-audio-device)
-[![macports](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fports.macports.org%2Fapi%2Fv1%2Fports%2Fproxy-audio-device%2F&query=%24.version&label=macports)](https://ports.macports.org/port/proxy-audio-device/)
+[![Packaging status on repology](https://repology.org/badge/vertical-allrepos/proxy-audio-device.svg)](https://repology.org/project/proxy-audio-device/versions)
 
 Install [proxy-audio-device with Homebrew with `brew`](https://formulae.brew.sh/cask/proxy-audio-device)
 _or_ [proxy-audio-device on macports with `port`](https://ports.macports.org/port/proxy-audio-device/):


### PR DESCRIPTION
This also adds some nice badges from shields.io to show the current version available in the two package managers.

proxy-audio-device was added to Homebrew in https://github.com/Homebrew/homebrew-cask/commit/466a3a6bc2e56fec47941882fd83b1855abad534