### PR TITLE
fixed macos sonoma

### DIFF
--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -5631,7 +5631,9 @@ CFStringRef ProxyAudioDevice::copyDefaultProxyOutputDeviceUID() {
     AudioObjectID defaultDevice = AudioDevice::defaultOutputDevice();
     
     if (defaultDevice != kAudioObjectUnknown) {
-        CFStringSmartRef uid = AudioDevice::copyDeviceUID(defaultDevice);
+        // Using CFStringSmartRef here will break macOS sonoma.
+        // CFStringSmartRef uid = AudioDevice::copyDeviceUID(defaultDevice);
+        CFStringRef uid = AudioDevice::copyDeviceUID(defaultDevice);
         
         if (uid && CFStringCompare(uid, CFSTR(kDevice_UID), 0) != kCFCompareEqualTo) {
             DebugMsg("ProxyAudio: copyDefaultProxyOutputDeviceUID returning default output device");


### PR DESCRIPTION
On Sonoma, the HAL Driver will crash if not upgraded from previous macOS versions.

```
CFStringSmartRef uid = AudioDevice::copyDeviceUID(defaultDevice);
```

Setting uid to `CFStringSmartRef` type will break the objective c runtime(complaints missing isa property). see `ProxyAudioDevice.cpp:4670`  



```
Thread 5 Crashed::  Dispatch queue: net.briankendall.ProxyAudioDevice.audioOutputQueue
0   libobjc.A.dylib               	       0x1896ad420 objc_msgSend + 32
1   ProxyAudioDevice              	       0x102d634f4 ProxyAudioDevice::findTargetOutputAudioDevice() + 236 (ProxyAudioDevice.cpp:4670)
2   ProxyAudioDevice              	       0x102d63c40 ProxyAudioDevice::setupTargetOutputDevice() + 56 (ProxyAudioDevice.cpp:4883)
3   ProxyAudioDevice              	       0x102d644fc invocation function for block in ProxyAudioDevice::initializeOutputDevice() + 104 (ProxyAudioDevice.cpp:4935)
4   libdispatch.dylib             	       0x1898c5910 _dispatch_client_callout + 20
5   libdispatch.dylib             	       0x1898c8dc8 _dispatch_continuation_pop + 600
6   libdispatch.dylib             	       0x1898dcbe4 _dispatch_source_latch_and_call + 420
7   libdispatch.dylib             	       0x1898db7b4 _dispatch_source_invoke + 832
8   libdispatch.dylib             	       0x1898ccd28 _dispatch_lane_serial_drain + 368
9   libdispatch.dylib             	       0x1898cd9d4 _dispatch_lane_invoke + 380
10  libdispatch.dylib             	       0x1898d861c _dispatch_root_queue_drain_deferred_wlh + 288
11  libdispatch.dylib             	       0x1898d7e90 _dispatch_workloop_worker_thread + 404
12  libsystem_pthread.dylib       	       0x189a6f114 _pthread_wqthread + 288
13  libsystem_pthread.dylib       	       0x189a6de30 start_wqthread + 8
```
