### PR TITLE
fix(readme): audio restart cmd for macOS 14.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ Run the _Proxy Audio Device Settings_ app to configure your new audio device.
 
 4. Either reboot your system or reboot Core Audio by executing the following command:
 
+        # macOS <= 13
         sudo launchctl kickstart -k system/com.apple.audio.coreaudiod
+   
+        # macOS >= 14.4
+        sudo killall coreaudiod
 
-5. Run Proxy Audio Device Settings to configure the proxy output device's name, which output device the driver will proxy to, and how large you want its audio buffer to be.
+6. Run Proxy Audio Device Settings to configure the proxy output device's name, which output device the driver will proxy to, and how large you want its audio buffer to be.
 
 ### Uninstallation
 
@@ -44,8 +48,12 @@ Run the _Proxy Audio Device Settings_ app to configure your new audio device.
         sudo rm -rf /Library/Audio/Plug-Ins/HAL/ProxyAudioDevice.driver
 
 2. Either reboot your system or reboot Core Audio by executing the following command:
-        
+
+        # macOS <= 13
         sudo launchctl kickstart -k system/com.apple.audio.coreaudiod
+   
+        # macOS >= 14.4
+        sudo killall coreaudiod
 
 ### Building
 


### PR DESCRIPTION
`sudo launchctl kickstart -k system/com.apple.audio.coreaudiod` doesn't work on macOS Sonoma 14.7.

This issue has more details: https://github.com/Homebrew/homebrew-cask/issues/171570

Apparently, since macOS 14.4, coreaudiod can just be killed normally, and this serves the same purpose. It's unclear to me whether this same issue / fix exists on 14.0 - 14.3, and I don't have it installed to validate.