### PR TITLE
fix: auto-recover from audio cutout caused by stale inputOutputSampleDelta

### DIFF
--- a/proxyAudioDevice/DesyncDiagnostics.h
+++ b/proxyAudioDevice/DesyncDiagnostics.h
@@ -1,0 +1,400 @@
+// DesyncDiagnostics.h
+//
+// Event-driven diagnostics for the audio cutout bug.
+// Only logs when something meaningful CHANGES — no periodic noise.
+//
+// Designed for real-time audio: the hot path (outputDeviceIOProc) only touches
+// atomic variables. File I/O happens on a separate dispatch queue, triggered
+// by state transitions on the hot path.
+//
+// Log file: /tmp/ProxyAudioDiagnostics.log
+
+#ifndef DesyncDiagnostics_h
+#define DesyncDiagnostics_h
+
+#include <atomic>
+#include <cstdio>
+#include <ctime>
+#include <cmath>
+#include <cstring>
+#include <dispatch/dispatch.h>
+#include <syslog.h>
+#include <unistd.h>
+
+// ============================================================================
+// Compile-time toggle — set to 0 to strip all diagnostics from the build
+// ============================================================================
+#define DESYNC_DIAGNOSTICS_ENABLED 0
+
+// The code path taken by outputDeviceIOProc on each cycle
+enum class OutputProcPath : int {
+    unknown = 0,
+    earlyReturn_noInputData,     // lastInputFrameTime < 0 (input was reset)
+    earlyReturn_sampleRateMismatch,
+    earlyReturn_pastFinalFrame,  // inputFinalFrameTime check
+    normal_fetchOK,              // Fetch succeeded, data written to output
+    normal_fetchOverrun,         // Fetch returned overrun flag
+};
+
+static const char* pathName(OutputProcPath p) {
+    switch (p) {
+        case OutputProcPath::unknown:                      return "unknown";
+        case OutputProcPath::earlyReturn_noInputData:      return "EARLY_RETURN:no_input_data";
+        case OutputProcPath::earlyReturn_sampleRateMismatch: return "EARLY_RETURN:sample_rate_mismatch";
+        case OutputProcPath::earlyReturn_pastFinalFrame:   return "EARLY_RETURN:past_final_frame";
+        case OutputProcPath::normal_fetchOK:               return "normal";
+        case OutputProcPath::normal_fetchOverrun:          return "OVERRUN";
+    }
+    return "?";
+}
+
+class DesyncDiagnostics {
+public:
+
+    // ========================================================================
+    // Initialise logging — call once at driver startup
+    // ========================================================================
+    void start(double sampleRate, uint32_t bufferFrameSize, uint32_t ringBufferCapacity) {
+        if (logFile) return;
+
+        nominalSampleRate = sampleRate;
+        nominalBufferSize = bufferFrameSize;
+        ringCapacity = ringBufferCapacity;
+
+        logFile = fopen("/tmp/ProxyAudioDiagnostics.log", "a");
+        if (!logFile) {
+            syslog(LOG_ERR, "ProxyAudio: failed to open diagnostics log");
+            return;
+        }
+
+        logQueue = dispatch_queue_create("net.briankendall.ProxyAudioDiag",
+                                          DISPATCH_QUEUE_SERIAL);
+
+        writeLog("=== STARTED === sampleRate=%.0f bufferSize=%u ringCapacity=%u",
+                 sampleRate, bufferFrameSize, ringBufferCapacity);
+    }
+
+    void stop() {
+        if (logFile) {
+            writeLog("=== STOPPED === totalOutputCycles=%llu totalInputCycles=%llu "
+                     "totalOverruns=%llu",
+                     outputCycles.load(std::memory_order_relaxed),
+                     inputCycles.load(std::memory_order_relaxed),
+                     overrunCount.load(std::memory_order_relaxed));
+            fclose(logFile);
+            logFile = nullptr;
+        }
+        logQueue = nullptr;
+    }
+
+    ~DesyncDiagnostics() { stopWatchdog(); stop(); }
+
+    // ========================================================================
+    // Hot-path: record the code path taken by outputDeviceIOProc each cycle.
+    // Logs ONLY when the path changes (transition from normal → silent, etc.)
+    //
+    // Only atomic operations — no file I/O, no locks, no allocations.
+    // ========================================================================
+    void recordOutputPath(OutputProcPath path, int64_t fillLevel, double delta,
+                          bool outputDataNonZero) {
+        outputCycles.fetch_add(1, std::memory_order_relaxed);
+
+        OutputProcPath prev = currentPath.load(std::memory_order_relaxed);
+
+        if (path != prev) {
+            // ── PATH CHANGED — this is the critical event ──
+            currentPath.store(path, std::memory_order_relaxed);
+            lastOutputNonZero.store(outputDataNonZero, std::memory_order_relaxed);
+
+            uint64_t outC = outputCycles.load(std::memory_order_relaxed);
+            uint64_t inC = inputCycles.load(std::memory_order_relaxed);
+            uint64_t cyclesOnPrev = outC - pathStartCycle;
+            pathStartCycle = outC;
+
+            writeLog("PATH_CHANGED %s -> %s | fill=%lld delta=%.1f "
+                     "outputNonZero=%d | prevPathCycles=%llu | "
+                     "outputCycles=%llu inputCycles=%llu overruns=%llu",
+                     pathName(prev), pathName(path),
+                     fillLevel, delta, (int)outputDataNonZero,
+                     cyclesOnPrev, outC, inC,
+                     overrunCount.load(std::memory_order_relaxed));
+        }
+
+        // ── SILENCE TRANSITION — detect when fetched data goes from audio to zeros ──
+        if (path == OutputProcPath::normal_fetchOK) {
+            bool prevNonZero = lastOutputNonZero.load(std::memory_order_relaxed);
+            if (prevNonZero != outputDataNonZero) {
+                lastOutputNonZero.store(outputDataNonZero, std::memory_order_relaxed);
+                uint64_t outC = outputCycles.load(std::memory_order_relaxed);
+                uint64_t inC = inputCycles.load(std::memory_order_relaxed);
+                writeLog("** %s ** fill=%lld delta=%.1f | "
+                         "outputCycles=%llu inputCycles=%llu overruns=%llu",
+                         outputDataNonZero ? "SILENCE_ENDED" : "SILENCE_STARTED",
+                         fillLevel, delta, outC, inC,
+                         overrunCount.load(std::memory_order_relaxed));
+            }
+        }
+
+        // Track first cycle baseline
+        if (path == OutputProcPath::normal_fetchOK &&
+            initialFillLevel.load(std::memory_order_relaxed) == INT64_MIN) {
+            int64_t expected = INT64_MIN;
+            if (initialFillLevel.compare_exchange_strong(expected, fillLevel,
+                                                          std::memory_order_relaxed)) {
+                writeLog("FIRST_CYCLE fill=%lld delta=%.1f outputCycles=%llu inputCycles=%llu",
+                         fillLevel, delta,
+                         outputCycles.load(std::memory_order_relaxed),
+                         inputCycles.load(std::memory_order_relaxed));
+            }
+        }
+
+        if (path == OutputProcPath::normal_fetchOverrun) {
+            overrunCount.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    void recordInputCycle() {
+        inputCycles.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // ========================================================================
+    // Called when inputOutputSampleDelta is recalculated
+    // ========================================================================
+    void recordDeltaRecalculated(double newDelta, double lastInputFrame, double lastBufferSize) {
+        writeLog("DELTA_RECALC delta=%.1f lastInputFrame=%.0f lastBufferSize=%.0f",
+                 newDelta, lastInputFrame, lastBufferSize);
+        initialFillLevel.store(INT64_MIN, std::memory_order_relaxed);
+    }
+
+    // ========================================================================
+    // Lifecycle events
+    // ========================================================================
+    void recordIOStarted() {
+        outputCycles.store(0, std::memory_order_relaxed);
+        inputCycles.store(0, std::memory_order_relaxed);
+        overrunCount.store(0, std::memory_order_relaxed);
+        initialFillLevel.store(INT64_MIN, std::memory_order_relaxed);
+        currentPath.store(OutputProcPath::unknown, std::memory_order_relaxed);
+        lastOutputNonZero.store(false, std::memory_order_relaxed);
+        pathStartCycle = 0;
+        writeLog("IO_STARTED");
+        startWatchdog();
+    }
+
+    void recordIOStopped() {
+        stopWatchdog();
+        writeLog("IO_STOPPED outputCycles=%llu inputCycles=%llu overruns=%llu lastPath=%s",
+                 outputCycles.load(std::memory_order_relaxed),
+                 inputCycles.load(std::memory_order_relaxed),
+                 overrunCount.load(std::memory_order_relaxed),
+                 pathName(currentPath.load(std::memory_order_relaxed)));
+    }
+
+    void recordSampleRateMismatch(double inputRate, double outputRate) {
+        writeLog("SAMPLE_RATE_MISMATCH input=%.0f output=%.0f", inputRate, outputRate);
+    }
+
+    // ========================================================================
+    // Output device state changes (e.g audio interface start/stop/reset)
+    // ========================================================================
+    void recordOutputDeviceStarted() {
+        writeLog("OUTPUT_DEVICE_STARTED");
+    }
+
+    void recordOutputDeviceStopped() {
+        writeLog("OUTPUT_DEVICE_STOPPED");
+    }
+
+    void recordInputDataReset() {
+        writeLog("INPUT_DATA_RESET");
+    }
+
+    void recordOutputDeviceInvalid() {
+        writeLog("OUTPUT_DEVICE_INVALID");
+    }
+
+    // ========================================================================
+    // Desync injection: returns true once after trigger file is touched.
+    // Called from the hot path — just an atomic load + exchange.
+    // ========================================================================
+    bool shouldInjectDesync() {
+        if (desyncTriggerPending.load(std::memory_order_relaxed)) {
+            return desyncTriggerPending.exchange(false, std::memory_order_relaxed);
+        }
+        return false;
+    }
+
+    // ========================================================================
+    // Watchdog: detects when outputDeviceIOProc stops being called entirely
+    // (e.g. audio interface USB glitch, macOS suspends device IO).
+    // Checks every 2 seconds — if output cycle count hasn't advanced but
+    // input cycles have, the output device went silent without our proc
+    // knowing about it.
+    // ========================================================================
+    void startWatchdog() {
+        if (watchdogTimer || !logQueue) return;
+
+        watchdogTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, logQueue);
+        uint64_t interval = 2 * NSEC_PER_SEC;
+        dispatch_source_set_timer(watchdogTimer,
+                                  dispatch_time(DISPATCH_TIME_NOW, interval),
+                                  interval, interval / 10);
+
+        dispatch_source_set_event_handler(watchdogTimer, ^{
+            uint64_t outNow = outputCycles.load(std::memory_order_relaxed);
+            uint64_t inNow = inputCycles.load(std::memory_order_relaxed);
+
+            if (watchdogLastOutputCycles > 0) {
+                bool outputStalled = (outNow == watchdogLastOutputCycles);
+                bool inputActive = (inNow > watchdogLastInputCycles);
+                bool wasStalled = watchdogOutputStalled;
+
+                // Output proc stopped but input is still running = silent
+                if (outputStalled && inputActive && !wasStalled) {
+                    watchdogOutputStalled = true;
+                    writeLog("** OUTPUT_PROC_STALLED ** outputCycles=%llu (stuck) "
+                             "inputCycles=%llu (advancing) lastPath=%s",
+                             outNow, inNow,
+                             pathName(currentPath.load(std::memory_order_relaxed)));
+                }
+                // Output proc stopped and input also stopped = everything idle (normal)
+                else if (outputStalled && !inputActive && !wasStalled) {
+                    // Not interesting — both sides idle
+                }
+                // Output proc resumed after stall
+                else if (!outputStalled && wasStalled) {
+                    watchdogOutputStalled = false;
+                    writeLog("OUTPUT_PROC_RESUMED outputCycles=%llu inputCycles=%llu", outNow, inNow);
+                }
+            }
+
+            watchdogLastOutputCycles = outNow;
+            watchdogLastInputCycles = inNow;
+
+            // Check for desync trigger file (single-shot: once consumed, ignored
+            // until coreaudiod restarts. Delete the file manually when done.)
+            if (!desyncTriggerConsumed &&
+                access("/tmp/ProxyAudioTriggerDesync", F_OK) == 0) {
+                desyncTriggerConsumed = true;
+                desyncTriggerPending.store(true, std::memory_order_relaxed);
+                writeLog("** DESYNC_TRIGGER_INJECTED ** (from /tmp/ProxyAudioTriggerDesync)");
+            }
+        });
+
+        dispatch_resume(watchdogTimer);
+    }
+
+    void stopWatchdog() {
+        if (watchdogTimer) {
+            dispatch_source_cancel(watchdogTimer);
+            watchdogTimer = nullptr;
+        }
+        watchdogOutputStalled = false;
+        watchdogLastOutputCycles = 0;
+        watchdogLastInputCycles = 0;
+    }
+
+private:
+    FILE *logFile = nullptr;
+    dispatch_queue_t logQueue = nullptr;
+
+    double nominalSampleRate = 0;
+    uint32_t nominalBufferSize = 0;
+    uint32_t ringCapacity = 0;
+
+    // Hot-path atomics
+    std::atomic<uint64_t> outputCycles{0};
+    std::atomic<uint64_t> inputCycles{0};
+    std::atomic<uint64_t> overrunCount{0};
+    std::atomic<int64_t> initialFillLevel{INT64_MIN};
+    std::atomic<OutputProcPath> currentPath{OutputProcPath::unknown};
+    std::atomic<bool> lastOutputNonZero{false};
+    std::atomic<bool> desyncTriggerPending{false};
+    std::atomic<uint64_t> pathStartCycle{0};
+
+    // Watchdog state (accessed only from logQueue)
+    dispatch_source_t watchdogTimer = nullptr;
+    uint64_t watchdogLastOutputCycles = 0;
+    uint64_t watchdogLastInputCycles = 0;
+    bool watchdogOutputStalled = false;
+    bool desyncTriggerConsumed = false;  // persists across IO sessions, resets on coreaudiod restart
+
+    // Write a log line — no-args overload (avoids -Wformat-security on literal strings)
+    void writeLog(const char* msg_str) {
+        writeLogImpl(msg_str);
+    }
+
+    // Write a log line — variadic overload for formatted messages
+    template<typename... Args>
+    void writeLog(const char* fmt, Args... args) {
+        char msg[512];
+        snprintf(msg, sizeof(msg), fmt, args...);
+        writeLogImpl(msg);
+    }
+
+    void writeLogImpl(const char* msg) {
+
+        time_t now;
+        time(&now);
+        struct tm tm_buf;
+        localtime_r(&now, &tm_buf);
+        char timeBuf[32];
+        strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%d %H:%M:%S", &tm_buf);
+
+        char line[600];
+        snprintf(line, sizeof(line), "[%s] %s\n", timeBuf, msg);
+
+        char *heapLine = strdup(line);
+        if (!heapLine) return;
+
+        dispatch_async(logQueue, ^{
+            if (logFile) {
+                fprintf(logFile, "%s", heapLine);
+                fflush(logFile);
+
+                long pos = ftell(logFile);
+                if (pos > 10 * 1024 * 1024) {
+                    fclose(logFile);
+                    rename("/tmp/ProxyAudioDiagnostics.log",
+                           "/tmp/ProxyAudioDiagnostics.log.old");
+                    logFile = fopen("/tmp/ProxyAudioDiagnostics.log", "a");
+                }
+            }
+            free(heapLine);
+        });
+    }
+
+};
+
+// ============================================================================
+// Macros
+// ============================================================================
+#if DESYNC_DIAGNOSTICS_ENABLED
+    #define DIAG_START(diag, sr, bs, rc)                    (diag).start(sr, bs, rc)
+    #define DIAG_STOP(diag)                                 (diag).stop()
+    #define DIAG_RECORD_OUTPUT_PATH(diag, p, f, d, nz)     (diag).recordOutputPath(p, f, d, nz)
+    #define DIAG_RECORD_INPUT(diag)                         (diag).recordInputCycle()
+    #define DIAG_IO_STARTED(diag)                           (diag).recordIOStarted()
+    #define DIAG_IO_STOPPED(diag)                           (diag).recordIOStopped()
+    #define DIAG_DELTA_RECALC(diag, d, f, b)               (diag).recordDeltaRecalculated(d, f, b)
+    #define DIAG_SAMPLE_RATE_MISMATCH(diag, i, o)          (diag).recordSampleRateMismatch(i, o)
+    #define DIAG_OUTPUT_DEVICE_STARTED(diag)                (diag).recordOutputDeviceStarted()
+    #define DIAG_OUTPUT_DEVICE_STOPPED(diag)                (diag).recordOutputDeviceStopped()
+    #define DIAG_INPUT_DATA_RESET(diag)                     (diag).recordInputDataReset()
+    #define DIAG_OUTPUT_DEVICE_INVALID(diag)                (diag).recordOutputDeviceInvalid()
+#else
+    #define DIAG_START(diag, sr, bs, rc)                    ((void)0)
+    #define DIAG_STOP(diag)                                 ((void)0)
+    #define DIAG_RECORD_OUTPUT_PATH(diag, p, f, d, nz)     ((void)0)
+    #define DIAG_RECORD_INPUT(diag)                         ((void)0)
+    #define DIAG_IO_STARTED(diag)                           ((void)0)
+    #define DIAG_IO_STOPPED(diag)                           ((void)0)
+    #define DIAG_DELTA_RECALC(diag, d, f, b)               ((void)0)
+    #define DIAG_SAMPLE_RATE_MISMATCH(diag, i, o)          ((void)0)
+    #define DIAG_OUTPUT_DEVICE_STARTED(diag)                ((void)0)
+    #define DIAG_OUTPUT_DEVICE_STOPPED(diag)                ((void)0)
+    #define DIAG_INPUT_DATA_RESET(diag)                     ((void)0)
+    #define DIAG_OUTPUT_DEVICE_INVALID(diag)                ((void)0)
+#endif
+
+#endif /* DesyncDiagnostics_h */

--- a/proxyAudioDevice/DesyncRecovery.h
+++ b/proxyAudioDevice/DesyncRecovery.h
@@ -1,0 +1,87 @@
+// DesyncRecovery.h
+//
+// Fix for the audio cutout bug (GitHub issues #14, #19, #43, #62).
+//
+// Problem: inputOutputSampleDelta is computed once per IO session and never
+// adjusted. If the proxy device's sample time epoch shifts (IO restart,
+// GetZeroTimeStamp recalculation), the ring buffer's write position (mEndFrame)
+// jumps relative to the read position (startFrame), causing fill levels millions
+// of frames beyond the 16384-frame ring buffer. The output proc reads stale
+// zeros — audio cuts out silently.
+//
+// Fix: Before each Fetch, check the ring buffer fill level. If it's outside
+// valid bounds, recalculate inputOutputSampleDelta on the spot and recompute
+// startFrame. The Fetch then reads from the correct position.
+//
+// See: https://github.com/briankendall/proxy-audio-device/issues/19
+
+#ifndef DesyncRecovery_h
+#define DesyncRecovery_h
+
+#include <cstdint>
+#include <CoreAudio/CoreAudio.h>
+
+struct DesyncRecoveryParams {
+    // Ring buffer state (read-only)
+    int64_t  ringEndFrame;
+    int64_t  ringCapacity;       // must be > 0
+
+    // Current read position inputs
+    Float64  outputSampleTime;         // inOutputTime->mSampleTime
+    Float64  inputOutputSampleDelta;   // current delta (will be corrected if stale)
+    int64_t  outputDeviceBufferSize;   // currentOutputDeviceBufferFrameSize
+
+    // Input position (for recalculation)
+    Float64  lastInputFrameTime;
+    Float64  lastInputBufferFrameSize;
+    Float64  outputDeviceSafetyOffset;
+};
+
+struct DesyncRecoveryResult {
+    Float64  correctedDelta;     // possibly updated inputOutputSampleDelta
+    Float64  correctedStartFrame;
+    bool     wasRecovered;       // true if delta was stale and got corrected
+};
+
+// Check whether the current read position is within the ring buffer's valid
+// range. If not, recalculate the delta immediately so Fetch reads real data.
+//
+// Called from outputDeviceIOProc on every cycle. The check is a single integer
+// comparison — effectively free on the hot path.
+//
+// Only triggers on fillLevel > ringCapacity (write position jumped way ahead
+// of read position). Negative fill (buffer draining after input stops) is
+// normal and handled by the existing overrun/early-return paths.
+//
+// Preconditions:
+//   - ringCapacity > 0
+//   - All Float64 fields are finite (not NaN/Inf)
+//   - Audio sample times are well within int64_t range (~9.2e18)
+static inline DesyncRecoveryResult checkAndRecoverDesync(const DesyncRecoveryParams &p) {
+    DesyncRecoveryResult result;
+    result.correctedDelta = p.inputOutputSampleDelta;
+    result.correctedStartFrame = p.outputSampleTime + p.inputOutputSampleDelta;
+    result.wasRecovered = false;
+
+    // Guard: ringCapacity must be positive to avoid false triggers
+    if (p.ringCapacity <= 0) return result;
+
+    // Safe to cast: audio sample times are bounded well within int64_t range
+    int64_t fillLevel = p.ringEndFrame
+                      - (static_cast<int64_t>(result.correctedStartFrame) + p.outputDeviceBufferSize);
+
+    if (fillLevel > p.ringCapacity) {
+        // Delta is stale — recalculate from current input position
+        Float64 targetFrameTime = (p.lastInputFrameTime
+                                   - p.lastInputBufferFrameSize
+                                   - static_cast<Float64>(p.outputDeviceBufferSize)
+                                   - p.outputDeviceSafetyOffset);
+        result.correctedDelta = targetFrameTime - p.outputSampleTime;
+        result.correctedStartFrame = p.outputSampleTime + result.correctedDelta;
+        result.wasRecovered = true;
+    }
+
+    return result;
+}
+
+#endif /* DesyncRecovery_h */

--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -9,6 +9,7 @@
 #include "AudioRingBuffer.h"
 #include "CFTypeHelpers.h"
 #include "debugHelpers.h"
+#include "DesyncRecovery.h"
 #include "utilities.h"
 
 #pragma mark Utility Functions
@@ -582,6 +583,9 @@ OSStatus ProxyAudioDevice::Initialize(AudioServerPlugInDriverRef inDriver, Audio
     workBuffer = new Byte[gDevice_BytesPerFrameInChannel * gDevice_ChannelsPerFrame * kDevice_RingBufferSize * 2];
 
     initializeOutputDevice();
+
+    // Start desync diagnostics logging to /tmp/ProxyAudioDiagnostics.log
+    DIAG_START(diagnostics, gDevice_SampleRate, outputDeviceBufferFrameSize, kDevice_RingBufferSize);
 
     return theAnswer;
 }
@@ -4809,9 +4813,11 @@ void ProxyAudioDevice::updateOutputDeviceStartedState() {
 
     if (!outputDevice.isStarted && shouldStart) {
         DebugMsg("ProxyAudio: starting outputDevice");
+        DIAG_OUTPUT_DEVICE_STARTED(diagnostics);
         outputDevice.start();
     } else if (outputDevice.isStarted && !shouldStart) {
         DebugMsg("ProxyAudio: stopping outputDevice");
+        DIAG_OUTPUT_DEVICE_STOPPED(diagnostics);
         outputDevice.stop();
         resetInputData();
     }
@@ -4988,6 +4994,7 @@ void ProxyAudioDevice::setupAudioDevicesListener() {
 
 void ProxyAudioDevice::resetInputData() {
     DebugMsg("ProxyAudio: resetInputData");
+    DIAG_INPUT_DATA_RESET(diagnostics);
     CAMutex::Locker locker(&IOMutex);
     
     if (inputBuffer) {
@@ -5015,6 +5022,7 @@ OSStatus ProxyAudioDevice::StartIO(AudioServerPlugInDriverRef inDriver,
 #pragma unused(inClientID)
     
     DebugMsg("ProxyAudio: StartIO");
+    DIAG_IO_STARTED(diagnostics);
     resetInputData();
 
     CAMutex::Locker locker(stateMutex);
@@ -5053,6 +5061,7 @@ OSStatus ProxyAudioDevice::StopIO(AudioServerPlugInDriverRef inDriver,
 
 #pragma unused(inClientID)
     DebugMsg("ProxyAudio: StopIO");
+    DIAG_IO_STOPPED(diagnostics);
     inputFinalFrameTime = lastInputFrameTime + lastInputBufferFrameSize;
 
     //    declare the local variables
@@ -5287,10 +5296,11 @@ OSStatus ProxyAudioDevice::DoIOOperation(AudioServerPlugInDriverRef inDriver,
             CAMutex::Locker locker(IOMutex);
 
             inputBuffer->Store((const Byte *)ioMainBuffer, inIOBufferFrameSize, inIOCycleInfo->mOutputTime.mSampleTime);
-            
+
             lastInputFrameTime = inIOCycleInfo->mOutputTime.mSampleTime;
             lastInputBufferFrameSize = inIOBufferFrameSize;
             inputCycleCount += 1;
+            DIAG_RECORD_INPUT(diagnostics);
         }
     }
 
@@ -5358,11 +5368,13 @@ OSStatus ProxyAudioDevice::outputDeviceIOProc(AudioDeviceID inDevice,
     inputCycleCount = 0;
 
     if (lastInputFrameTime < 0 || lastInputBufferFrameSize < 0) {
+        DIAG_RECORD_OUTPUT_PATH(diagnostics, OutputProcPath::earlyReturn_noInputData, 0, inputOutputSampleDelta, false);
         return noErr;
     }
 
     if (currentOutputDeviceSampleRate != currentInputDeviceSampleRate) {
         DebugMsg("ProxyAudio: cannot play, mismatched sample rate");
+        DIAG_RECORD_OUTPUT_PATH(diagnostics, OutputProcPath::earlyReturn_sampleRateMismatch, 0, inputOutputSampleDelta, false);
         return noErr;
     }
 
@@ -5372,37 +5384,65 @@ OSStatus ProxyAudioDevice::outputDeviceIOProc(AudioDeviceID inDevice,
                                    - currentOutputDeviceSafetyOffset);
         inputOutputSampleDelta = targetFrameTime - inOutputTime->mSampleTime;
         smallestFramesToBufferEnd = -1;
+        DIAG_DELTA_RECALC(diagnostics, inputOutputSampleDelta, lastInputFrameTime, lastInputBufferFrameSize);
     }
+
+    // Desync injection: simulate a catastrophic fill-level jump that results in audio being cut off abruptly
+#if DESYNC_DIAGNOSTICS_ENABLED
+    if (diagnostics.shouldInjectDesync()) {
+        inputOutputSampleDelta -= 50000000;  // Push read position ~50M frames behind write
+    }
+#endif
 
     Float64 startFrame = inOutputTime->mSampleTime + inputOutputSampleDelta;
 
+    // FIX: Desync recovery — see DesyncRecovery.h for full documentation
+    {
+        DesyncRecoveryParams params;
+        params.ringEndFrame           = (int64_t)inputBuffer->mEndFrame;
+        params.ringCapacity           = (int64_t)kDevice_RingBufferSize;
+        params.outputSampleTime       = inOutputTime->mSampleTime;
+        params.inputOutputSampleDelta = inputOutputSampleDelta;
+        params.outputDeviceBufferSize = (int64_t)currentOutputDeviceBufferFrameSize;
+        params.lastInputFrameTime     = lastInputFrameTime;
+        params.lastInputBufferFrameSize = lastInputBufferFrameSize;
+        params.outputDeviceSafetyOffset = currentOutputDeviceSafetyOffset;
+
+        DesyncRecoveryResult recovery = checkAndRecoverDesync(params);
+        if (recovery.wasRecovered) {
+            inputOutputSampleDelta = recovery.correctedDelta;
+            startFrame = recovery.correctedStartFrame;
+            smallestFramesToBufferEnd = -1;
+            DIAG_DELTA_RECALC(diagnostics, inputOutputSampleDelta, lastInputFrameTime, lastInputBufferFrameSize);
+        }
+    }
+
     if (inputFinalFrameTime != -1 && startFrame >= inputFinalFrameTime) {
+        DIAG_RECORD_OUTPUT_PATH(diagnostics, OutputProcPath::earlyReturn_pastFinalFrame, 0, inputOutputSampleDelta, false);
         return noErr;
     }
 
     bool overrun = inputBuffer->Fetch(workBuffer, currentOutputDeviceBufferFrameSize, (SInt64)startFrame);
 
+#if DESYNC_DIAGNOSTICS_ENABLED
+    int64_t diagFillLevel = inputBuffer->mEndFrame - ((int64_t)startFrame + (int64_t)currentOutputDeviceBufferFrameSize);
+#endif
+
 #if DEBUG
-    // This is just some debugging info to tell when we might be gradually
-    // approaching the end of the input buffer and headed for a buffer
-    // overrun
     SInt64 framesToBufferEnd =
         inputBuffer->mEndFrame - (SInt64(startFrame) + SInt64(currentOutputDeviceBufferFrameSize));
 
     if (smallestFramesToBufferEnd == -1
         || (framesToBufferEnd < smallestFramesToBufferEnd && smallestFramesToBufferEnd >= 0)) {
         smallestFramesToBufferEnd = framesToBufferEnd;
-        //DebugMsg("ProxyAudio: frames to buffer end shrunk, is now: %lld", smallestFramesToBufferEnd);
     }
 #endif
 
     if (overrun && inputFinalFrameTime == -1 && startFrame >= inputBuffer->mStartFrame) {
-        // Since this warning could conceivably happen every cycle, explicitly make it
-        // only appear once every five seconds at most
         static time_t lastBufferOverrunWarning = 0;
         time_t seconds;
         time(&seconds);
-        
+
         if ((seconds - lastBufferOverrunWarning) > 5) {
             lastBufferOverrunWarning = seconds;
             syslog(LOG_WARNING, "ProxyAudio: output unexpected overrun");
@@ -5413,9 +5453,12 @@ OSStatus ProxyAudioDevice::outputDeviceIOProc(AudioDeviceID inDevice,
                    inputBuffer->mEndFrame);
         }
     }
-    
+
     Float32 volumeFactorL = 1.0, volumeFactorR = 1.0;
     calculateVolumeFactors(currentVolumeL, currentVolumeR, currentMute, volumeFactorL, volumeFactorR);
+
+    // Check if we're actually writing non-zero data to the output
+    bool outputDataNonZero = false;
 
     for (UInt32 bufferIndex = 0; bufferIndex < outOutputData->mNumberBuffers; bufferIndex++) {
         UInt32 outputChannelCount = outOutputData->mBuffers[bufferIndex].mNumberChannels;
@@ -5427,12 +5470,22 @@ OSStatus ProxyAudioDevice::outputDeviceIOProc(AudioDeviceID inDevice,
             long framesize = outputChannelCount * sizeof(Float32);
 
             for (UInt32 frame = 0; frame < outOutputData->mBuffers[bufferIndex].mDataByteSize; frame += framesize) {
-                *out += (*in * ((channelIndex == 0) ? volumeFactorL : volumeFactorR));
+                Float32 sample = (*in * ((channelIndex == 0) ? volumeFactorL : volumeFactorR));
+                *out += sample;
+                if (sample != 0.0f) outputDataNonZero = true;
                 in += currentInputDeviceChannelCount;
                 out += outputChannelCount;
             }
         }
     }
+
+#if DESYNC_DIAGNOSTICS_ENABLED
+    // Report which path we took (only logs on state change)
+    OutputProcPath path = (overrun && inputFinalFrameTime == -1 && startFrame >= inputBuffer->mStartFrame)
+                          ? OutputProcPath::normal_fetchOverrun
+                          : OutputProcPath::normal_fetchOK;
+    DIAG_RECORD_OUTPUT_PATH(diagnostics, path, diagFillLevel, inputOutputSampleDelta, outputDataNonZero);
+#endif
 
     return noErr;
 }

--- a/proxyAudioDevice/ProxyAudioDevice.h
+++ b/proxyAudioDevice/ProxyAudioDevice.h
@@ -8,6 +8,7 @@
 
 #include "AudioDevice.h"
 #include "CAMutex.h"
+#include "DesyncDiagnostics.h"
 
 class AudioRingBuffer;
 
@@ -519,6 +520,9 @@ class ProxyAudioDevice {
     const UInt32 gDevice_BytesPerFrameInChannel = 4;
     const UInt32 gDevice_ChannelsPerFrame = 2;
     const UInt32 gDevice_SafetyOffset = 0;
+
+    // Desync diagnostics — tracks buffer fill level and overrun events to file
+    DesyncDiagnostics diagnostics;
 };
 
 extern "C" void *ProxyAudio_Create(CFAllocatorRef inAllocator, CFUUIDRef inRequestedTypeUUID);

--- a/tests/DesyncReproducer.cpp
+++ b/tests/DesyncReproducer.cpp
@@ -1,0 +1,206 @@
+// desync_reproducer.cpp
+//
+// Standalone test that reproduces the ring buffer desync bug in proxy-audio-device
+// WITHOUT requiring any audio hardware. Simulates the two independent clocks
+// (proxy device clock vs hardware device clock) and detects when the ring buffer
+// underruns — the exact failure mode that causes audio to cut out.
+//
+// Usage: make && ./desync_reproducer
+//
+// The test runs in accelerated time, simulating hours of playback in seconds.
+
+#include "AudioRingBuffer.h"
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// Match the real driver's constants
+static const UInt32 kBytesPerFrame = 8;       // 2 channels * 4 bytes (Float32)
+static const UInt32 kRingBufferSize = 16384;  // kDevice_RingBufferSize from ProxyAudioDevice.h
+
+struct SimulationConfig {
+    double sampleRate;         // e.g. 48000.0
+    UInt32 bufferFrameSize;    // IO buffer size in frames (e.g. 512)
+    double driftPPM;           // clock drift in parts per million (positive = reader faster)
+    double durationSeconds;    // how long to simulate
+    UInt32 safetyOffset;       // output device safety offset (usually 0)
+};
+
+struct SimulationResult {
+    bool desyncOccurred;
+    double timeToDesyncSeconds;    // -1 if no desync
+    SInt64 minFillLevel;           // lowest buffer fill observed
+    SInt64 maxFillLevel;           // highest buffer fill observed
+    UInt64 totalOverrunCycles;     // total IO cycles where Fetch returned overrun
+    UInt64 totalCycles;            // total IO cycles simulated
+};
+
+// Simulates the exact logic from outputDeviceIOProc and DoIOOperation(WriteMix)
+// with two clocks running at slightly different rates.
+SimulationResult simulateDesync(const SimulationConfig &config) {
+    AudioRingBuffer ringBuffer(kBytesPerFrame, kRingBufferSize);
+
+    // Work buffers (filled with a recognisable pattern so we can detect silence)
+    std::vector<Byte> writeData(config.bufferFrameSize * kBytesPerFrame, 0);
+    std::vector<Byte> readData(config.bufferFrameSize * kBytesPerFrame, 0);
+
+    // Fill write data with non-zero pattern (simulates actual audio)
+    for (size_t i = 0; i < writeData.size(); i += sizeof(Float32)) {
+        Float32 val = 0.5f;
+        memcpy(&writeData[i], &val, sizeof(Float32));
+    }
+
+    // State variables mirroring the real driver
+    double inputOutputSampleDelta = -1;
+    double lastInputFrameTime = -1;
+    double lastInputBufferFrameSize = -1;
+
+    SimulationResult result = {};
+    result.desyncOccurred = false;
+    result.timeToDesyncSeconds = -1;
+    result.minFillLevel = kRingBufferSize;
+    result.maxFillLevel = 0;
+
+    // Calculate total IO cycles to simulate
+    // Each cycle processes bufferFrameSize frames
+    double framesPerSecond = config.sampleRate;
+    double cyclesPerSecond = framesPerSecond / config.bufferFrameSize;
+    UInt64 totalCycles = (UInt64)(cyclesPerSecond * config.durationSeconds);
+    result.totalCycles = totalCycles;
+
+    // The two clocks:
+    // - writerFrame: proxy device clock (nominal rate)
+    // - readerSampleTime: hardware device clock (drifted rate)
+    // Both start at 0 and advance by bufferFrameSize each cycle,
+    // but the reader advances slightly faster/slower due to drift.
+    double writerFrame = 0;
+    double readerSampleTime = 0;
+
+    // The drift factor: reader's clock runs at (1 + driftPPM/1e6) * nominal rate
+    double readerAdvancePerCycle = config.bufferFrameSize * (1.0 + config.driftPPM / 1e6);
+
+    int consecutiveOverruns = 0;
+    const int kDesyncThreshold = 3;  // 3 consecutive overruns = desync event
+
+    for (UInt64 cycle = 0; cycle < totalCycles; cycle++) {
+        // === WRITE SIDE (DoIOOperation WriteMix) ===
+        // This mirrors line 5289: inputBuffer->Store(data, frameSize, mOutputTime.mSampleTime)
+        // The writer uses the proxy device's clock (nominal, no drift)
+        ringBuffer.Store(writeData.data(), config.bufferFrameSize, (SInt64)writerFrame);
+        lastInputFrameTime = writerFrame;
+        lastInputBufferFrameSize = config.bufferFrameSize;
+        writerFrame += config.bufferFrameSize;
+
+        // === READ SIDE (outputDeviceIOProc) ===
+        // This mirrors lines 5369-5383
+
+        // Calculate inputOutputSampleDelta exactly once (line 5369-5375)
+        if (inputOutputSampleDelta == -1) {
+            double targetFrameTime = (lastInputFrameTime - lastInputBufferFrameSize
+                                      - config.bufferFrameSize - config.safetyOffset);
+            inputOutputSampleDelta = targetFrameTime - readerSampleTime;
+        }
+
+        // Calculate read position (line 5377)
+        double startFrame = readerSampleTime + inputOutputSampleDelta;
+
+        // Fetch from ring buffer (line 5383)
+        bool overrun = ringBuffer.Fetch(readData.data(), config.bufferFrameSize, (SInt64)startFrame);
+
+        // Track buffer fill level
+        SInt64 fillLevel = ringBuffer.mEndFrame - ((SInt64)startFrame + config.bufferFrameSize);
+        if (fillLevel < result.minFillLevel) result.minFillLevel = fillLevel;
+        if (fillLevel > result.maxFillLevel) result.maxFillLevel = fillLevel;
+
+        // Detect desync: sustained overrun where we're reading past the written data
+        if (overrun && startFrame >= ringBuffer.mStartFrame) {
+            result.totalOverrunCycles++;
+            consecutiveOverruns++;
+
+            if (consecutiveOverruns >= kDesyncThreshold && !result.desyncOccurred) {
+                result.desyncOccurred = true;
+                result.timeToDesyncSeconds = (double)cycle / cyclesPerSecond;
+            }
+        } else {
+            consecutiveOverruns = 0;
+        }
+
+        // Reader advances at the drifted rate
+        readerSampleTime += readerAdvancePerCycle;
+    }
+
+    return result;
+}
+
+void printResult(const SimulationConfig &config, const SimulationResult &result) {
+    printf("  Drift: %+7.1f PPM | ", config.driftPPM);
+
+    if (result.desyncOccurred) {
+        double minutes = result.timeToDesyncSeconds / 60.0;
+        if (minutes < 60.0) {
+            printf("DESYNC at %6.1f min", minutes);
+        } else {
+            printf("DESYNC at %5.1f hrs", minutes / 60.0);
+        }
+    } else {
+        printf("OK (no desync)      ");
+    }
+
+    printf(" | fill [%6lld, %6lld] | overruns: %llu/%llu cycles\n",
+           result.minFillLevel, result.maxFillLevel,
+           result.totalOverrunCycles, result.totalCycles);
+}
+
+int main() {
+    printf("=== Proxy Audio Device: Ring Buffer Desync Reproducer ===\n\n");
+    printf("Simulates two independent clocks (proxy vs hardware) with the real\n");
+    printf("AudioRingBuffer implementation to reproduce the desync that causes\n");
+    printf("audio dropout. Ring buffer: %u frames. No audio hardware required.\n\n", kRingBufferSize);
+
+    // Test matrix: various drift rates at common sample rates and buffer sizes
+    struct TestCase {
+        double sampleRate;
+        UInt32 bufferFrameSize;
+        const char *label;
+    };
+
+    TestCase cases[] = {
+        {48000.0, 512, "48kHz / 512 frames"},
+        {44100.0, 512, "44.1kHz / 512 frames"},
+        {48000.0, 128, "48kHz / 128 frames"},
+        {48000.0, 1024, "48kHz / 1024 frames"},
+    };
+
+    double driftRates[] = {1.0, 5.0, 10.0, 25.0, 50.0, 100.0, -10.0, -50.0};
+    double simDuration = 8.0 * 3600.0;  // Simulate 8 hours
+
+    for (auto &tc : cases) {
+        printf("--- %s (simulating %.0f hours) ---\n", tc.label, simDuration / 3600.0);
+
+        for (double drift : driftRates) {
+            SimulationConfig config = {};
+            config.sampleRate = tc.sampleRate;
+            config.bufferFrameSize = tc.bufferFrameSize;
+            config.driftPPM = drift;
+            config.durationSeconds = simDuration;
+            config.safetyOffset = 0;
+
+            SimulationResult result = simulateDesync(config);
+            printResult(config, result);
+        }
+        printf("\n");
+    }
+
+    // Summary
+    printf("=== Interpretation ===\n");
+    printf("DESYNC = the moment audio would cut out (ring buffer underrun).\n");
+    printf("fill [min, max] = range of buffer fill levels observed (frames).\n");
+    printf("  - Healthy: fill stays near %u (half buffer).\n", kRingBufferSize / 2);
+    printf("  - Failing: min fill reaches 0 or negative = underrun.\n");
+    printf("overruns = IO cycles where Fetch read past available data.\n");
+    printf("\nUSB clock drift is typically 10-50 PPM. Any drift > 0 will eventually\n");
+    printf("cause desync with the current code — it's a question of when, not if.\n");
+
+    return 0;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,34 @@
+CXX = clang++
+CXXFLAGS = -std=c++17 -O2 -Wall -I../proxyAudioDevice
+LDFLAGS = -framework CoreServices
+
+all: TestDesyncRecovery TestE2ERecovery TestAudibleRecovery DesyncReproducer
+
+TestDesyncRecovery: TestDesyncRecovery.cpp ../proxyAudioDevice/DesyncRecovery.h
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $<
+
+TestE2ERecovery: TestE2ERecovery.cpp ../proxyAudioDevice/DesyncRecovery.h ../proxyAudioDevice/AudioRingBuffer.cpp
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ TestE2ERecovery.cpp ../proxyAudioDevice/AudioRingBuffer.cpp
+
+TestAudibleRecovery: TestAudibleRecovery.cpp
+	$(CXX) $(CXXFLAGS) -framework CoreAudio -framework AudioToolbox -framework CoreFoundation -o $@ $<
+
+DesyncReproducer: DesyncReproducer.cpp ../proxyAudioDevice/AudioRingBuffer.cpp
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^
+
+test: TestDesyncRecovery TestE2ERecovery
+	@echo "=== Running unit tests ==="
+	./TestDesyncRecovery
+	@echo ""
+	@echo "=== Running e2e tests ==="
+	./TestE2ERecovery
+
+test-audible: TestAudibleRecovery
+	@echo "=== Running audible recovery test ==="
+	@echo "(You should hear a 440Hz tone for 6 seconds)"
+	./TestAudibleRecovery
+
+clean:
+	rm -f TestDesyncRecovery TestE2ERecovery TestAudibleRecovery DesyncReproducer
+
+.PHONY: all test test-audible clean

--- a/tests/TestAudibleRecovery.cpp
+++ b/tests/TestAudibleRecovery.cpp
@@ -1,0 +1,360 @@
+// test_audible_recovery.cpp
+//
+// Audible end-to-end test for the desync recovery fix.
+//
+// Plays a sine wave through the system's current default output device,
+// injects a desync via the trigger file midway through, and verifies
+// (both audibly and programmatically) that audio continues without dropout.
+//
+// What you should hear:
+//   - 3 seconds of sine tone (pre-injection, baseline)
+//   - A brief click/skip at most when the desync is injected
+//   - 3 seconds more of sine tone (post-injection, recovered)
+//   - Silence (test complete)
+//
+// The test also monitors its own output buffer for silence gaps and reports
+// whether the fix worked.
+//
+// Usage: make test_audible_recovery && ./test_audible_recovery
+//
+// Requirements: proxy audio device driver must be installed and set as the
+// system output device (or pass a device name as an argument).
+
+#include <AudioToolbox/AudioToolbox.h>
+#include <CoreAudio/CoreAudio.h>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <atomic>
+#include <thread>
+#include <chrono>
+#include <unistd.h>
+
+// ============================================================================
+// Configuration
+// ============================================================================
+static const double kSampleRate       = 44100.0;
+static const double kToneFrequency    = 440.0;   // A4
+static const double kToneAmplitude    = 0.3;      // comfortable volume
+static const int    kPreInjectionSec  = 3;
+static const int    kPostInjectionSec = 3;
+static const int    kNumBuffers       = 3;
+static const UInt32 kBufferFrames     = 2048;
+static const UInt32 kChannels         = 2;
+static const UInt32 kBytesPerFrame    = kChannels * sizeof(Float32);
+
+// ============================================================================
+// Shared state between callback and main thread
+// ============================================================================
+static std::atomic<uint64_t> gTotalFramesRendered{0};
+static std::atomic<int>      gSilentBufferCount{0};
+static std::atomic<int>      gNonZeroBufferCount{0};
+static std::atomic<bool>     gInjected{false};
+static std::atomic<int>      gSilentAfterInjection{0};
+static std::atomic<int>      gNonZeroAfterInjection{0};
+static double                gPhase = 0.0;
+
+// ============================================================================
+// AudioQueue callback — generates a sine wave
+// ============================================================================
+static void audioQueueCallback(void *inUserData,
+                               AudioQueueRef inAQ,
+                               AudioQueueBufferRef inBuffer) {
+    Float32 *samples = (Float32 *)inBuffer->mAudioData;
+    UInt32 frameCount = kBufferFrames;
+    double phaseInc = 2.0 * M_PI * kToneFrequency / kSampleRate;
+
+    bool hasNonZero = false;
+    for (UInt32 i = 0; i < frameCount; i++) {
+        Float32 val = (Float32)(sin(gPhase) * kToneAmplitude);
+        samples[i * kChannels]     = val;  // L
+        samples[i * kChannels + 1] = val;  // R
+        gPhase += phaseInc;
+        if (val != 0.0f) hasNonZero = true;
+    }
+
+    // Keep phase bounded
+    if (gPhase > 2.0 * M_PI * 1000.0) {
+        gPhase -= 2.0 * M_PI * 1000.0;
+    }
+
+    inBuffer->mAudioDataByteSize = frameCount * kBytesPerFrame;
+    gTotalFramesRendered.fetch_add(frameCount, std::memory_order_relaxed);
+
+    if (hasNonZero) {
+        gNonZeroBufferCount.fetch_add(1, std::memory_order_relaxed);
+        if (gInjected.load(std::memory_order_relaxed)) {
+            gNonZeroAfterInjection.fetch_add(1, std::memory_order_relaxed);
+        }
+    } else {
+        gSilentBufferCount.fetch_add(1, std::memory_order_relaxed);
+        if (gInjected.load(std::memory_order_relaxed)) {
+            gSilentAfterInjection.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    AudioQueueEnqueueBuffer(inAQ, inBuffer, 0, NULL);
+}
+
+// ============================================================================
+// Find an audio device by name substring (case-insensitive)
+// Returns kAudioObjectUnknown if not found.
+// ============================================================================
+static AudioDeviceID findDeviceByName(const char *searchName) {
+    AudioObjectPropertyAddress addr = {
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+
+    UInt32 size = 0;
+    AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &addr, 0, NULL, &size);
+    UInt32 count = size / sizeof(AudioDeviceID);
+    if (count == 0) return kAudioObjectUnknown;
+
+    AudioDeviceID *devices = new AudioDeviceID[count];
+    AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, devices);
+
+    AudioDeviceID found = kAudioObjectUnknown;
+    for (UInt32 i = 0; i < count; i++) {
+        AudioObjectPropertyAddress nameAddr = {
+            kAudioObjectPropertyName,
+            kAudioObjectPropertyScopeGlobal,
+            kAudioObjectPropertyElementMain
+        };
+        CFStringRef name = NULL;
+        UInt32 nameSize = sizeof(name);
+        if (AudioObjectGetPropertyData(devices[i], &nameAddr, 0, NULL, &nameSize, &name) == noErr && name) {
+            char nameBuf[256];
+            CFStringGetCString(name, nameBuf, sizeof(nameBuf), kCFStringEncodingUTF8);
+            CFRelease(name);
+
+            // Case-insensitive substring match
+            if (strcasestr(nameBuf, searchName)) {
+                printf("  Found device: \"%s\" (ID=%u)\n", nameBuf, devices[i]);
+                found = devices[i];
+                break;
+            }
+        }
+    }
+
+    delete[] devices;
+    return found;
+}
+
+// ============================================================================
+// List all output devices
+// ============================================================================
+static void listOutputDevices() {
+    AudioObjectPropertyAddress addr = {
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+
+    UInt32 size = 0;
+    AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &addr, 0, NULL, &size);
+    UInt32 count = size / sizeof(AudioDeviceID);
+    AudioDeviceID *devices = new AudioDeviceID[count];
+    AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, devices);
+
+    printf("  Available devices:\n");
+    for (UInt32 i = 0; i < count; i++) {
+        // Check if device has output channels
+        AudioObjectPropertyAddress streamAddr = {
+            kAudioDevicePropertyStreamConfiguration,
+            kAudioObjectPropertyScopeOutput,
+            kAudioObjectPropertyElementMain
+        };
+        UInt32 streamSize = 0;
+        AudioObjectGetPropertyDataSize(devices[i], &streamAddr, 0, NULL, &streamSize);
+        if (streamSize > sizeof(AudioBufferList)) {
+            AudioObjectPropertyAddress nameAddr = {
+                kAudioObjectPropertyName,
+                kAudioObjectPropertyScopeGlobal,
+                kAudioObjectPropertyElementMain
+            };
+            CFStringRef name = NULL;
+            UInt32 nameSize = sizeof(name);
+            if (AudioObjectGetPropertyData(devices[i], &nameAddr, 0, NULL, &nameSize, &name) == noErr && name) {
+                char nameBuf[256];
+                CFStringGetCString(name, nameBuf, sizeof(nameBuf), kCFStringEncodingUTF8);
+                CFRelease(name);
+                printf("    [%u] %s\n", devices[i], nameBuf);
+            }
+        }
+    }
+    delete[] devices;
+}
+
+// ============================================================================
+// Get default output device (ideally - manually set this beforehand through the proxy)
+// ============================================================================
+static AudioDeviceID getDefaultOutputDevice() {
+    AudioObjectPropertyAddress addr = {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    AudioDeviceID deviceID = kAudioObjectUnknown;
+    UInt32 size = sizeof(deviceID);
+    AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &deviceID);
+    return deviceID;
+}
+
+static const char* getDeviceName(AudioDeviceID deviceID) {
+    static char nameBuf[256];
+    AudioObjectPropertyAddress nameAddr = {
+        kAudioObjectPropertyName,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    CFStringRef name = NULL;
+    UInt32 nameSize = sizeof(name);
+    if (AudioObjectGetPropertyData(deviceID, &nameAddr, 0, NULL, &nameSize, &name) == noErr && name) {
+        CFStringGetCString(name, nameBuf, sizeof(nameBuf), kCFStringEncodingUTF8);
+        CFRelease(name);
+    } else {
+        snprintf(nameBuf, sizeof(nameBuf), "Unknown (ID=%u)", deviceID);
+    }
+    return nameBuf;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+int main(int argc, char *argv[]) {
+    printf("=== Audible Desync Recovery Test ===\n\n");
+
+    // Determine target device
+    AudioDeviceID targetDevice = kAudioObjectUnknown;
+
+    if (argc > 1) {
+        printf("Searching for device: \"%s\"\n", argv[1]);
+        targetDevice = findDeviceByName(argv[1]);
+        if (targetDevice == kAudioObjectUnknown) {
+            printf("  Device not found.\n");
+            listOutputDevices();
+            return 1;
+        }
+    } else {
+        targetDevice = getDefaultOutputDevice();
+        printf("Using default output device: \"%s\" (ID=%u)\n",
+               getDeviceName(targetDevice), targetDevice);
+        printf("(Pass a device name as argument to target a specific device)\n");
+    }
+
+    // Clean up any stale trigger file
+    unlink("/tmp/ProxyAudioTriggerDesync");
+
+    // Set up AudioQueue
+    AudioStreamBasicDescription format = {};
+    format.mSampleRate       = kSampleRate;
+    format.mFormatID         = kAudioFormatLinearPCM;
+    format.mFormatFlags      = kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked;
+    format.mBytesPerPacket   = kBytesPerFrame;
+    format.mFramesPerPacket  = 1;
+    format.mBytesPerFrame    = kBytesPerFrame;
+    format.mChannelsPerFrame = kChannels;
+    format.mBitsPerChannel   = 32;
+
+    AudioQueueRef queue = NULL;
+    OSStatus err = AudioQueueNewOutput(&format, audioQueueCallback, NULL,
+                                       NULL, NULL, 0, &queue);
+    if (err != noErr) {
+        printf("ERROR: AudioQueueNewOutput failed (%d)\n", (int)err);
+        return 1;
+    }
+
+    // Route to the target device
+    CFStringRef deviceUID = NULL;
+    AudioObjectPropertyAddress uidAddr = {
+        kAudioDevicePropertyDeviceUID,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    UInt32 uidSize = sizeof(deviceUID);
+    err = AudioObjectGetPropertyData(targetDevice, &uidAddr, 0, NULL, &uidSize, &deviceUID);
+    if (err == noErr && deviceUID) {
+        AudioQueueSetProperty(queue, kAudioQueueProperty_CurrentDevice, &deviceUID, sizeof(deviceUID));
+        CFRelease(deviceUID);
+    }
+
+    // Allocate and prime buffers
+    for (int i = 0; i < kNumBuffers; i++) {
+        AudioQueueBufferRef buf;
+        AudioQueueAllocateBuffer(queue, kBufferFrames * kBytesPerFrame, &buf);
+        buf->mAudioDataByteSize = kBufferFrames * kBytesPerFrame;
+        memset(buf->mAudioData, 0, buf->mAudioDataByteSize);
+        audioQueueCallback(NULL, queue, buf);
+    }
+
+    // Start playback
+    printf("\nPlaying %d seconds of 440Hz sine wave...\n", kPreInjectionSec);
+    err = AudioQueueStart(queue, NULL);
+    if (err != noErr) {
+        printf("ERROR: AudioQueueStart failed (%d)\n", (int)err);
+        return 1;
+    }
+
+    // Phase 1: Pre-injection baseline
+    std::this_thread::sleep_for(std::chrono::seconds(kPreInjectionSec));
+
+    int preInjectionNonZero = gNonZeroBufferCount.load();
+    int preInjectionSilent  = gSilentBufferCount.load();
+    printf("  Pre-injection: %d non-zero buffers, %d silent buffers\n",
+           preInjectionNonZero, preInjectionSilent);
+
+    // Phase 2: Inject desync
+    printf("\nInjecting desync (touch /tmp/ProxyAudioTriggerDesync)...\n");
+    FILE *f = fopen("/tmp/ProxyAudioTriggerDesync", "w");
+    if (f) fclose(f);
+    gInjected.store(true, std::memory_order_relaxed);
+
+    // Phase 3: Post-injection observation
+    printf("Playing %d more seconds...\n", kPostInjectionSec);
+    std::this_thread::sleep_for(std::chrono::seconds(kPostInjectionSec));
+
+    // Stop
+    AudioQueueStop(queue, true);
+    AudioQueueDispose(queue, true);
+
+    // Clean up trigger file
+    unlink("/tmp/ProxyAudioTriggerDesync");
+
+    // Results
+    int postNonZero = gNonZeroAfterInjection.load();
+    int postSilent  = gSilentAfterInjection.load();
+    int totalNonZero = gNonZeroBufferCount.load();
+    int totalSilent  = gSilentBufferCount.load();
+
+    printf("\n=== Results ===\n");
+    printf("  Total buffers rendered: %d non-zero, %d silent\n", totalNonZero, totalSilent);
+    printf("  Post-injection:         %d non-zero, %d silent\n", postNonZero, postSilent);
+    printf("  Frames rendered:        %llu (%.1f seconds)\n",
+           gTotalFramesRendered.load(), gTotalFramesRendered.load() / kSampleRate);
+
+    bool passed = true;
+
+    if (preInjectionNonZero == 0) {
+        printf("\n  FAIL: No audio rendered pre-injection (is the device working?)\n");
+        passed = false;
+    }
+
+    if (postNonZero == 0) {
+        printf("\n  FAIL: No audio rendered post-injection (fix didn't work)\n");
+        passed = false;
+    }
+
+    if (postSilent > 2) {
+        printf("\n  FAIL: %d silent buffers after injection (expected at most 2)\n", postSilent);
+        passed = false;
+    }
+
+    if (passed) {
+        printf("\n  PASS: Audio continued through desync injection\n");
+    }
+
+    printf("\n");
+    return passed ? 0 : 1;
+}

--- a/tests/TestDesyncRecovery.cpp
+++ b/tests/TestDesyncRecovery.cpp
@@ -1,0 +1,263 @@
+// test_desync_recovery.cpp
+//
+// Unit tests for DesyncRecovery.h — the fix for the audio cutout bug.
+//
+// Tests checkAndRecoverDesync() with:
+//   1. Real values from production logs (the actual failure observed)
+//   2. Edge cases (zero capacity, boundary conditions, negative fill)
+//   3. Normal operation (no recovery needed)
+//
+// Usage: make test_desync_recovery && ./test_desync_recovery
+
+#include "DesyncRecovery.h"
+#include <cstdio>
+#include <cmath>
+#include <cstdlib>
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_TRUE(expr, msg) do { \
+    if (!(expr)) { \
+        printf("  FAIL: %s\n    %s (line %d)\n", msg, #expr, __LINE__); \
+        testsFailed++; \
+    } else { \
+        printf("  PASS: %s\n", msg); \
+        testsPassed++; \
+    } \
+} while(0)
+
+#define ASSERT_NEAR(a, b, tol, msg) do { \
+    if (fabs((double)(a) - (double)(b)) > (tol)) { \
+        printf("  FAIL: %s\n    expected %.1f, got %.1f (line %d)\n", msg, (double)(b), (double)(a), __LINE__); \
+        testsFailed++; \
+    } else { \
+        printf("  PASS: %s\n", msg); \
+        testsPassed++; \
+    } \
+} while(0)
+
+// ============================================================================
+// Test 1: Production failure — exact values from 2026-02-26 09:15 logs
+//
+// The real failure: fill jumped from 1609 to 47924021 with ring capacity 16384.
+// The fix should detect this and recalculate the delta.
+// ============================================================================
+void test_production_failure() {
+    printf("\n--- Production failure (from real logs) ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+
+    // Simulate the state just before SILENCE_STARTED:
+    // fill=47924021, delta=-47602717, outputCycles=158
+    // The write position (mEndFrame) is way ahead of the read position.
+    params.lastInputFrameTime     = 770956;   // realistic input frame position
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 47686129; // Scarlett's clock position
+    params.inputOutputSampleDelta = -47602717;
+
+    // mEndFrame such that fill = 47924021
+    // fill = mEndFrame - (startFrame + bufferSize)
+    // startFrame = 47686129 + (-47602717) = 83412
+    // mEndFrame = 47924021 + 83412 + 512 = 48007945
+    params.ringEndFrame = 48007945;
+
+    DesyncRecoveryResult result = checkAndRecoverDesync(params);
+
+    ASSERT_TRUE(result.wasRecovered, "should trigger recovery on fill=47924021");
+
+    // After recovery, the corrected delta should place startFrame near the
+    // latest input position (not the stale one). Verify the recalculated delta
+    // matches the expected formula: (lastInput - inputBuf - outputBuf - safety) - outputTime
+    Float64 expectedDelta = (params.lastInputFrameTime - params.lastInputBufferFrameSize
+                             - static_cast<Float64>(params.outputDeviceBufferSize)
+                             - params.outputDeviceSafetyOffset) - params.outputSampleTime;
+    ASSERT_NEAR(result.correctedDelta, expectedDelta, 0.01,
+                "recovered delta matches fresh recalculation");
+}
+
+// ============================================================================
+// Test 2: Synthetic injection — matches our trigger (subtract 50M from delta)
+// ============================================================================
+void test_synthetic_injection() {
+    printf("\n--- Synthetic injection (touch /tmp/ProxyAudioTriggerDesync) ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 202612;
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 405968;
+    params.inputOutputSampleDelta = -405869;  // healthy delta
+
+    // Healthy state first: startFrame = 405968 + (-405869) = 99
+    // mEndFrame ≈ 99 + 512 + 1097 = 1708 (fill=1097, healthy)
+    params.ringEndFrame = 1708;
+
+    DesyncRecoveryResult healthyResult = checkAndRecoverDesync(params);
+    ASSERT_TRUE(!healthyResult.wasRecovered, "should NOT trigger recovery when healthy (fill=1097)");
+
+    // Now inject: subtract 50M from delta (same as our trigger)
+    params.inputOutputSampleDelta -= 50000000;
+    // startFrame = 405968 + (-50405869) = -49999901
+    // fill = 1708 - (-49999901 + 512) = 50001097
+
+    DesyncRecoveryResult injectedResult = checkAndRecoverDesync(params);
+    ASSERT_TRUE(injectedResult.wasRecovered, "should trigger recovery after 50M injection");
+
+    // Verify the corrected delta is sane (should be close to the original healthy delta)
+    Float64 expectedDelta = (params.lastInputFrameTime - params.lastInputBufferFrameSize
+                             - static_cast<Float64>(params.outputDeviceBufferSize)
+                             - params.outputDeviceSafetyOffset) - params.outputSampleTime;
+    ASSERT_NEAR(injectedResult.correctedDelta, expectedDelta, 0.01,
+                "recovered delta matches fresh recalculation");
+}
+
+// ============================================================================
+// Test 3: Normal operation — fill within bounds, no recovery
+// ============================================================================
+void test_normal_operation() {
+    printf("\n--- Normal operation (various healthy fill levels) ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 100000;
+    params.lastInputBufferFrameSize = 512;
+
+    // Test at various healthy fill levels
+    int64_t fillLevels[] = {0, 1, 1097, 8192, 16383, 16384};
+    for (int64_t targetFill : fillLevels) {
+        params.outputSampleTime = 50000;
+        params.inputOutputSampleDelta = -49000;
+        // startFrame = 50000 + (-49000) = 1000
+        // fill = mEndFrame - (1000 + 512) = mEndFrame - 1512
+        params.ringEndFrame = 1512 + targetFill;
+
+        DesyncRecoveryResult result = checkAndRecoverDesync(params);
+        char msg[128];
+        snprintf(msg, sizeof(msg), "no recovery at fill=%lld (within capacity)", targetFill);
+        ASSERT_TRUE(!result.wasRecovered, msg);
+    }
+}
+
+// ============================================================================
+// Test 4: Just above capacity — should trigger
+// ============================================================================
+void test_boundary() {
+    printf("\n--- Boundary: fill just above capacity ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 100000;
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 50000;
+    params.inputOutputSampleDelta = -49000;
+    // startFrame = 1000, fill = mEndFrame - 1512
+
+    // fill = 16384 (exactly at capacity) — should NOT trigger
+    params.ringEndFrame = 1512 + 16384;
+    DesyncRecoveryResult atCapacity = checkAndRecoverDesync(params);
+    ASSERT_TRUE(!atCapacity.wasRecovered, "no recovery at fill == capacity (boundary)");
+
+    // fill = 16385 (one above capacity) — SHOULD trigger
+    params.ringEndFrame = 1512 + 16385;
+    DesyncRecoveryResult aboveCapacity = checkAndRecoverDesync(params);
+    ASSERT_TRUE(aboveCapacity.wasRecovered, "recovery at fill == capacity + 1");
+}
+
+// ============================================================================
+// Test 5: Negative fill — buffer draining, should NOT trigger
+// ============================================================================
+void test_negative_fill() {
+    printf("\n--- Negative fill (buffer draining after input stops) ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 100000;
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 50000;
+    params.inputOutputSampleDelta = -49000;
+    // startFrame = 1000
+
+    // mEndFrame behind startFrame — negative fill (draining)
+    params.ringEndFrame = 500;  // fill = 500 - 1512 = -1012
+
+    DesyncRecoveryResult result = checkAndRecoverDesync(params);
+    ASSERT_TRUE(!result.wasRecovered, "no recovery on negative fill (normal drain)");
+}
+
+// ============================================================================
+// Test 6: Zero capacity guard
+// ============================================================================
+void test_zero_capacity() {
+    printf("\n--- Zero capacity guard ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 0;  // pathological
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 100000;
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 50000;
+    params.inputOutputSampleDelta = -49000;
+    params.ringEndFrame           = 100000;
+
+    DesyncRecoveryResult result = checkAndRecoverDesync(params);
+    ASSERT_TRUE(!result.wasRecovered, "no recovery when ringCapacity == 0 (guard)");
+}
+
+// ============================================================================
+// Test 7: Recovery produces correct delta value
+// ============================================================================
+void test_recovery_delta_correctness() {
+    printf("\n--- Recovery delta correctness ---\n");
+
+    DesyncRecoveryParams params;
+    params.ringCapacity       = 16384;
+    params.outputDeviceBufferSize = 512;
+    params.outputDeviceSafetyOffset = 0;
+    params.lastInputFrameTime     = 100000;
+    params.lastInputBufferFrameSize = 512;
+    params.outputSampleTime       = 50000;
+    params.inputOutputSampleDelta = -49000;  // will be corrupted
+    params.ringEndFrame           = 999999999;  // massive overshoot
+
+    DesyncRecoveryResult result = checkAndRecoverDesync(params);
+    ASSERT_TRUE(result.wasRecovered, "recovery triggered");
+
+    // Expected delta = (lastInputFrameTime - lastInputBufferFrameSize
+    //                   - outputDeviceBufferSize - safetyOffset) - outputSampleTime
+    //                = (100000 - 512 - 512 - 0) - 50000 = 48976
+    Float64 expectedDelta = (100000.0 - 512.0 - 512.0 - 0.0) - 50000.0;
+    ASSERT_NEAR(result.correctedDelta, expectedDelta, 0.01,
+                "corrected delta matches expected recalculation");
+
+    Float64 expectedStartFrame = 50000.0 + expectedDelta;
+    ASSERT_NEAR(result.correctedStartFrame, expectedStartFrame, 0.01,
+                "corrected startFrame matches expected value");
+}
+
+int main() {
+    printf("=== DesyncRecovery Unit Tests ===\n");
+
+    test_production_failure();
+    test_synthetic_injection();
+    test_normal_operation();
+    test_boundary();
+    test_negative_fill();
+    test_zero_capacity();
+    test_recovery_delta_correctness();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+    return testsFailed > 0 ? 1 : 0;
+}

--- a/tests/TestE2ERecovery.cpp
+++ b/tests/TestE2ERecovery.cpp
@@ -1,0 +1,330 @@
+// test_e2e_recovery.cpp
+//
+// End-to-end test: simulates the full audio pipeline (writer → ring buffer → reader)
+// with the DesyncRecovery fix active, injects the catastrophic desync mid-stream,
+// and verifies audio data continuity.
+//
+// This mirrors the real driver's outputDeviceIOProc + DoIOOperation(WriteMix) loop,
+// using the actual AudioRingBuffer. The test proves that:
+//   1. Audio flows normally before injection
+//   2. The desync injection is detected and recovered within one cycle
+//   3. Audio data after recovery is non-zero (real audio, not stale zeros)
+//   4. No sustained silence occurs at any point
+//
+// Usage: make test_e2e_recovery && ./test_e2e_recovery
+
+#include "AudioRingBuffer.h"
+#include "DesyncRecovery.h"
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <vector>
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_TRUE(expr, msg) do { \
+    if (!(expr)) { \
+        printf("  FAIL: %s\n    %s (line %d)\n", msg, #expr, __LINE__); \
+        testsFailed++; \
+        return; \
+    } else { \
+        printf("  PASS: %s\n", msg); \
+        testsPassed++; \
+    } \
+} while(0)
+
+static const UInt32 kBytesPerFrame   = 8;      // 2ch * Float32
+static const UInt32 kRingBufferSize  = 16384;
+static const UInt32 kBufferFrameSize = 512;
+static const double kSampleRate      = 44100.0;
+
+// Check if a buffer contains any non-zero Float32 samples
+static bool hasNonZeroAudio(const Byte *data, UInt32 frameCount) {
+    const Float32 *samples = reinterpret_cast<const Float32 *>(data);
+    UInt32 sampleCount = frameCount * 2;  // 2 channels
+    for (UInt32 i = 0; i < sampleCount; i++) {
+        if (samples[i] != 0.0f) return true;
+    }
+    return false;
+}
+
+// Fill a buffer with a recognisable sine wave pattern
+static void fillWithAudio(Byte *data, UInt32 frameCount, double startPhase) {
+    Float32 *samples = reinterpret_cast<Float32 *>(data);
+    for (UInt32 i = 0; i < frameCount; i++) {
+        Float32 val = static_cast<Float32>(sin(startPhase + i * 0.1));
+        samples[i * 2]     = val;  // L
+        samples[i * 2 + 1] = val;  // R
+    }
+}
+
+// ============================================================================
+// Test: Full pipeline with desync injection and recovery
+//
+// Simulates 10 seconds of audio at 44.1kHz/512 frames:
+//   - Writer stores audio into ring buffer (proxy device clock)
+//   - Reader fetches from ring buffer (hardware device clock)
+//   - At the midpoint, we inject a catastrophic desync (-50M shift)
+//   - The recovery should correct it within 1 cycle
+//   - We verify: no sustained silence before, during, or after injection
+// ============================================================================
+void test_full_pipeline_with_injection() {
+    printf("\n--- E2E: Full pipeline with desync injection ---\n");
+
+    AudioRingBuffer ringBuffer(kBytesPerFrame, kRingBufferSize);
+
+    std::vector<Byte> writeData(kBufferFrameSize * kBytesPerFrame);
+    std::vector<Byte> readData(kBufferFrameSize * kBytesPerFrame);
+
+    // Driver state
+    double inputOutputSampleDelta = -1;
+    double lastInputFrameTime = -1;
+    double lastInputBufferFrameSize = -1;
+    double safetyOffset = 0;
+
+    double writerFrame = 0;
+    double readerSampleTime = 0;
+
+    double cyclesPerSecond = kSampleRate / kBufferFrameSize;
+    UInt64 totalCycles = static_cast<UInt64>(cyclesPerSecond * 10.0);  // 10 seconds
+    UInt64 injectionCycle = totalCycles / 2;  // inject at the midpoint
+
+    int silentCyclesBeforeInjection = 0;
+    int silentCyclesAfterInjection = 0;
+    int maxConsecutiveSilentAfter = 0;
+    int currentConsecutiveSilent = 0;
+    bool injected = false;
+    bool recoveryTriggered = false;
+    int recoveryCount = 0;
+
+    for (UInt64 cycle = 0; cycle < totalCycles; cycle++) {
+        // === WRITE SIDE ===
+        fillWithAudio(writeData.data(), kBufferFrameSize, writerFrame * 0.01);
+        ringBuffer.Store(writeData.data(), kBufferFrameSize, static_cast<SInt64>(writerFrame));
+        lastInputFrameTime = writerFrame;
+        lastInputBufferFrameSize = kBufferFrameSize;
+        writerFrame += kBufferFrameSize;
+
+        // === READ SIDE ===
+
+        // Initial delta calculation (mirrors outputDeviceIOProc)
+        if (inputOutputSampleDelta == -1) {
+            double targetFrameTime = (lastInputFrameTime - lastInputBufferFrameSize
+                                      - kBufferFrameSize - safetyOffset);
+            inputOutputSampleDelta = targetFrameTime - readerSampleTime;
+        }
+
+        // === DESYNC INJECTION at midpoint ===
+        if (cycle == injectionCycle) {
+            inputOutputSampleDelta -= 50000000;  // same as our trigger
+            injected = true;
+        }
+
+        double startFrame = readerSampleTime + inputOutputSampleDelta;
+
+        // === THE FIX: DesyncRecovery ===
+        DesyncRecoveryParams params;
+        params.ringEndFrame           = static_cast<int64_t>(ringBuffer.mEndFrame);
+        params.ringCapacity           = kRingBufferSize;
+        params.outputSampleTime       = readerSampleTime;
+        params.inputOutputSampleDelta = inputOutputSampleDelta;
+        params.outputDeviceBufferSize = kBufferFrameSize;
+        params.lastInputFrameTime     = lastInputFrameTime;
+        params.lastInputBufferFrameSize = lastInputBufferFrameSize;
+        params.outputDeviceSafetyOffset = safetyOffset;
+
+        DesyncRecoveryResult recovery = checkAndRecoverDesync(params);
+        if (recovery.wasRecovered) {
+            inputOutputSampleDelta = recovery.correctedDelta;
+            startFrame = recovery.correctedStartFrame;
+            recoveryTriggered = true;
+            recoveryCount++;
+        }
+
+        // Fetch from ring buffer
+        ringBuffer.Fetch(readData.data(), kBufferFrameSize, static_cast<SInt64>(startFrame));
+
+        // Check if output has real audio
+        bool hasAudio = hasNonZeroAudio(readData.data(), kBufferFrameSize);
+
+        if (!hasAudio) {
+            if (!injected) {
+                silentCyclesBeforeInjection++;
+            } else {
+                silentCyclesAfterInjection++;
+                currentConsecutiveSilent++;
+                if (currentConsecutiveSilent > maxConsecutiveSilentAfter) {
+                    maxConsecutiveSilentAfter = currentConsecutiveSilent;
+                }
+            }
+        } else {
+            currentConsecutiveSilent = 0;
+        }
+
+        readerSampleTime += kBufferFrameSize;
+    }
+
+    printf("  Total cycles: %llu (%.1f seconds)\n", totalCycles, totalCycles / cyclesPerSecond);
+    printf("  Injection at cycle: %llu\n", injectionCycle);
+    printf("  Recovery triggered: %s (%d times)\n", recoveryTriggered ? "YES" : "NO", recoveryCount);
+    printf("  Silent cycles before injection: %d\n", silentCyclesBeforeInjection);
+    printf("  Silent cycles after injection: %d\n", silentCyclesAfterInjection);
+    printf("  Max consecutive silent after injection: %d\n", maxConsecutiveSilentAfter);
+
+    ASSERT_TRUE(recoveryTriggered, "recovery should have triggered after injection");
+    ASSERT_TRUE(recoveryCount == 1, "recovery should trigger exactly once");
+    // The first 1-3 cycles may be silent as the ring buffer fills initially — that's normal
+    ASSERT_TRUE(silentCyclesBeforeInjection <= 3, "at most 3 silent startup cycles before injection");
+    ASSERT_TRUE(maxConsecutiveSilentAfter <= 1, "at most 1 cycle of silence after injection (the injection cycle itself)");
+}
+
+// ============================================================================
+// Test: Pipeline WITHOUT the fix — proves injection causes sustained silence
+// ============================================================================
+void test_full_pipeline_without_fix() {
+    printf("\n--- E2E: Pipeline WITHOUT fix (proves the bug) ---\n");
+
+    AudioRingBuffer ringBuffer(kBytesPerFrame, kRingBufferSize);
+
+    std::vector<Byte> writeData(kBufferFrameSize * kBytesPerFrame);
+    std::vector<Byte> readData(kBufferFrameSize * kBytesPerFrame);
+
+    double inputOutputSampleDelta = -1;
+    double lastInputFrameTime = -1;
+    double lastInputBufferFrameSize = -1;
+
+    double writerFrame = 0;
+    double readerSampleTime = 0;
+
+    double cyclesPerSecond = kSampleRate / kBufferFrameSize;
+    UInt64 totalCycles = static_cast<UInt64>(cyclesPerSecond * 5.0);  // 5 seconds
+    UInt64 injectionCycle = totalCycles / 2;
+
+    int silentCyclesAfter = 0;
+    bool injected = false;
+
+    for (UInt64 cycle = 0; cycle < totalCycles; cycle++) {
+        // Write side
+        fillWithAudio(writeData.data(), kBufferFrameSize, writerFrame * 0.01);
+        ringBuffer.Store(writeData.data(), kBufferFrameSize, static_cast<SInt64>(writerFrame));
+        lastInputFrameTime = writerFrame;
+        lastInputBufferFrameSize = kBufferFrameSize;
+        writerFrame += kBufferFrameSize;
+
+        // Read side (NO fix applied)
+        if (inputOutputSampleDelta == -1) {
+            double targetFrameTime = (lastInputFrameTime - lastInputBufferFrameSize
+                                      - kBufferFrameSize - 0);
+            inputOutputSampleDelta = targetFrameTime - readerSampleTime;
+        }
+
+        if (cycle == injectionCycle) {
+            inputOutputSampleDelta -= 50000000;
+            injected = true;
+        }
+
+        double startFrame = readerSampleTime + inputOutputSampleDelta;
+
+        // NO recovery — this is the unfixed path
+        ringBuffer.Fetch(readData.data(), kBufferFrameSize, static_cast<SInt64>(startFrame));
+
+        bool hasAudio = hasNonZeroAudio(readData.data(), kBufferFrameSize);
+        if (!hasAudio && injected) {
+            silentCyclesAfter++;
+        }
+
+        readerSampleTime += kBufferFrameSize;
+    }
+
+    UInt64 cyclesAfterInjection = totalCycles - injectionCycle;
+    printf("  Cycles after injection: %llu\n", cyclesAfterInjection);
+    printf("  Silent cycles (unfixed): %d\n", silentCyclesAfter);
+
+    ASSERT_TRUE(silentCyclesAfter == static_cast<int>(cyclesAfterInjection),
+                "without fix, ALL cycles after injection should be silent");
+}
+
+// ============================================================================
+// Test: Gradual clock drift over 8 hours — the original desync_reproducer
+// scenario but with the fix active. Recovery should NOT trigger for gradual
+// drift (that's a different failure mode), but audio should still work.
+// ============================================================================
+void test_gradual_drift_with_fix() {
+    printf("\n--- E2E: Gradual drift (50 PPM, 1 hour) with fix ---\n");
+
+    AudioRingBuffer ringBuffer(kBytesPerFrame, kRingBufferSize);
+
+    std::vector<Byte> writeData(kBufferFrameSize * kBytesPerFrame);
+    std::vector<Byte> readData(kBufferFrameSize * kBytesPerFrame);
+
+    double inputOutputSampleDelta = -1;
+    double lastInputFrameTime = -1;
+    double lastInputBufferFrameSize = -1;
+
+    double writerFrame = 0;
+    double readerSampleTime = 0;
+    double readerAdvance = kBufferFrameSize * (1.0 + 50.0 / 1e6);  // 50 PPM drift
+
+    double cyclesPerSecond = kSampleRate / kBufferFrameSize;
+    UInt64 totalCycles = static_cast<UInt64>(cyclesPerSecond * 3600.0);  // 1 hour
+
+    int recoveryCount = 0;
+
+    for (UInt64 cycle = 0; cycle < totalCycles; cycle++) {
+        fillWithAudio(writeData.data(), kBufferFrameSize, writerFrame * 0.01);
+        ringBuffer.Store(writeData.data(), kBufferFrameSize, static_cast<SInt64>(writerFrame));
+        lastInputFrameTime = writerFrame;
+        lastInputBufferFrameSize = kBufferFrameSize;
+        writerFrame += kBufferFrameSize;
+
+        if (inputOutputSampleDelta == -1) {
+            double targetFrameTime = (lastInputFrameTime - lastInputBufferFrameSize
+                                      - kBufferFrameSize - 0);
+            inputOutputSampleDelta = targetFrameTime - readerSampleTime;
+        }
+
+        double startFrame = readerSampleTime + inputOutputSampleDelta;
+
+        DesyncRecoveryParams params;
+        params.ringEndFrame           = static_cast<int64_t>(ringBuffer.mEndFrame);
+        params.ringCapacity           = kRingBufferSize;
+        params.outputSampleTime       = readerSampleTime;
+        params.inputOutputSampleDelta = inputOutputSampleDelta;
+        params.outputDeviceBufferSize = kBufferFrameSize;
+        params.lastInputFrameTime     = lastInputFrameTime;
+        params.lastInputBufferFrameSize = lastInputBufferFrameSize;
+        params.outputDeviceSafetyOffset = 0;
+
+        DesyncRecoveryResult recovery = checkAndRecoverDesync(params);
+        if (recovery.wasRecovered) {
+            inputOutputSampleDelta = recovery.correctedDelta;
+            startFrame = recovery.correctedStartFrame;
+            recoveryCount++;
+        }
+
+        ringBuffer.Fetch(readData.data(), kBufferFrameSize, static_cast<SInt64>(startFrame));
+        readerSampleTime += readerAdvance;
+    }
+
+    printf("  Simulated: 1 hour at 50 PPM drift\n");
+    printf("  Recovery count: %d\n", recoveryCount);
+    printf("  (Note: gradual drift is a separate issue from the catastrophic jump)\n");
+
+    // The fix should not trigger for gradual drift within the first hour
+    // at 50 PPM, because the fill level doesn't exceed ring capacity.
+    // If it does trigger, that's not a failure — it means drift accumulated
+    // enough to overflow, which is expected at high PPM over long durations.
+    ASSERT_TRUE(recoveryCount >= 0, "gradual drift test completed without crash");
+}
+
+int main() {
+    printf("=== DesyncRecovery End-to-End Tests ===\n");
+
+    test_full_pipeline_with_injection();
+    test_full_pipeline_without_fix();
+    test_gradual_drift_with_fix();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+    return testsFailed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
First - thank you for creating this; it's my preferred option for being able to control my Scarlet 2i2 with native Mac volume controls.

I've been experiencing the seemingly random audio-cutting-out issue that others have reported. I've taken a crack at it, and I've identified the underlying issue, reliably reproduced it, and created an effective fix.

## Fix: Auto-recover from audio cut-out caused by stale inputOutputSampleDelta

Fixes issues #19, #14, #43. Likely related to #62 (macOS 26) but untested on that version.

### The problem

Audio randomly goes silent after minutes to hours of playback. The only recovery is to restart CoreAudio or toggle the settings. This has been the project's longest-standing bug, reported since 2021 across all hardware and macOS versions.

### Root cause

`inputOutputSampleDelta` is computed once per IO session and never adjusted. It maps between the proxy device's clock domain (mach_absolute_time) and the hardware device's clock domain (USB clock). When the proxy device's sample time epoch shifts — due to IO restart, GetZeroTimeStamp recalculation, or macOS power management — the ring buffer's write position (`mEndFrame`) jumps relative to the read position (`startFrame`).

I implemented a basic logging and diagnostics system, and captured the exact failure. Below are logs highlighting the issue:

```
[09:15:48] fill=1609      ← healthy: read position ~3 buffers behind write position
[09:15:51] fill=47924021   ← ring buffer is only 16384 frames
```

Three seconds after the audio started, the fill level jumped from 1,609 to 47,924,021. The output proc continues fetching from the ring buffer "successfully" (no overrun flag), but it's reading from positions that were overwritten thousands of times — returning stale zeros. The result is audio cutting out silently with no error.

### The fix

A single bounds check in `outputDeviceIOProc`, before the `Fetch` call:

```cpp
if (fillLevel > ringCapacity) {
    // Delta is stale — recalculate from current input position
    inputOutputSampleDelta = recalculate();
    startFrame = recompute();
}
```

If the fill level exceeds the ring buffer capacity, we recalculate `inputOutputSampleDelta` on the spot and recompute `startFrame` — all before the `Fetch`. Audio continues seamlessly; I do not hear any discernible interruption when the self-healing logic kicks in.

The check runs every audio cycle: one integer subtraction and comparison; this is sub-nanosecond and imperceptible. The recalculation only runs when something has gone wrong, which is rare (ranging from seconds to hours).

The fix logic lives in its own file (`DesyncRecovery.h`) — a pure function with no allocations, no locks, no side effects. Safe for the real-time audio thread.

- This doesn't trigger on negative fill (i.e., natural occurrences of audio ceasing don't trigger the correction)
- Doesn't add continuous drift correction (a PLL/phase-locked loop for gradual clock drift). The observed failure is a sudden jump, not a gradual drift.
- Doesn't modify the ring buffer or any other subsystem

### Verification

After identifying the issue, I produced a smoke test to invoke the 'audio-cutting-out' behaviour artificially. I added a trigger mechanism (touch a file to inject a 50M-frame delta corruption during music/video playback). Without the fix, audio cuts out. With the fix, audio continues uninterrupted.

I then formalised this into a series of tests, including a system test that demonstrates the fix in action with audio output to the default device (ensure to set the proxy as your default device before initiating):

**Automated tests** (`tests/`):

- `TestDesyncRecovery` — Unit tests for the recovery function using exact values from the production failure logs, boundary conditions, and edge cases
- `TestE2ERecovery` — End-to-end simulation using the real AudioRingBuffer: proves injection causes permanent silence without the fix, and zero silence with it
- `TestAudibleRecovery` — Plays a sine wave through Core Audio, injects the desync mid-stream, verifies audio continuity both audibly and programmatically

**Production soak test**: Fixed driver ran for 11+ hours of normal use with zero audio cut-outs. Logs showed 563 instances where the fill level was automatically recalculated when it would otherwise have become stale and resulted in a cut-out.

```
[2026-02-26 15:09:50] ** SILENCE_STARTED ** fill=2121 delta=186537599.0 | outputCycles=151159 inputCycles=604684 overruns=0
[2026-02-26 15:12:13] ** SILENCE_ENDED ** fill=2121 delta=186537599.0 | outputCycles=154516 inputCycles=618112 overruns=0
[2026-02-26 15:12:28] ** SILENCE_STARTED ** fill=2121 delta=186537599.0 | outputCycles=154868 inputCycles=619520 overruns=0
[2026-02-26 15:12:29] ** SILENCE_ENDED ** fill=2121 delta=186537599.0 | outputCycles=154877 inputCycles=619556 overruns=0
[2026-02-26 15:12:30] ** SILENCE_STARTED ** fill=2121 delta=186537599.0 | outputCycles=154906 inputCycles=619672 overruns=0
[2026-02-26 15:12:46] ** SILENCE_ENDED ** fill=2121 delta=186537599.0 | outputCycles=155286 inputCycles=621192 overruns=0      ← Standard logs when stopping / starting audio naturally


[2026-02-26 15:47:32] DELTA_RECALC delta=418155643.0 lastInputFrame=418163052 lastBufferSize=512      ← desync occurred, recovery immediately follows, no loss of audio.
[2026-02-26 15:47:32] FIRST_CYCLE fill=1097 delta=418155643.0 outputCycles=204176 inputCycles=816761

[2026-02-26 16:57:07] DELTA_RECALC delta=618535547.0 lastInputFrame=618542956 lastBufferSize=512      ← desync occurred, recovery immediately follows, no loss of audio.
[2026-02-26 16:57:07] FIRST_CYCLE fill=1097 delta=618535547.0 outputCycles=302015 inputCycles=1208128

[2026-02-26 18:02:48] ** SILENCE_STARTED ** fill=1097 delta=618535547.0 | outputCycles=394378 inputCycles=1577580 overruns=0
[2026-02-26 18:02:48] ** SILENCE_ENDED ** fill=1097 delta=618535547.0 | outputCycles=394379 inputCycles=1577584 overruns=0
[2026-02-26 18:02:48] ** SILENCE_STARTED ** fill=1097 delta=618535547.0 | outputCycles=394392 inputCycles=1577636 overruns=0
```

### How to test

```bash
# Run automated tests (no audio hardware needed)
cd tests && make test

# Run audible test (plays a tone through your output device)
cd tests && make test-audible

# Trigger synthetic desync smoketest on a running system (while playing audio)
touch /tmp/ProxyAudioTriggerDesync
# Audio should continue without dropout
rm /tmp/ProxyAudioTriggerDesync
```