### PR TITLE
Add "hide when unavailable" setting to gate PR #61 behavior

### DIFF
--- a/ProxyAudioDeviceSettings/Base.lproj/MainMenu.xib
+++ b/ProxyAudioDeviceSettings/Base.lproj/MainMenu.xib
@@ -18,6 +18,7 @@
                 <outlet property="alwaysRadioButton" destination="Qmk-xY-0ok" id="2yu-wp-avo"/>
                 <outlet property="bufferSizeComboBox" destination="Tu4-jv-3Xp" id="e5z-EY-esA"/>
                 <outlet property="deviceNameTextField" destination="Vuz-aO-zYY" id="Jbh-lS-r17"/>
+                <outlet property="hideWhenUnavailableCheckbox" destination="hWu-01-chk" id="hWu-01-out"/>
                 <outlet property="outputDeviceComboBox" destination="8bM-6q-Jq9" id="hOu-HN-ffg"/>
                 <outlet property="proxiedDeviceIsActiveRadioButton" destination="utN-wS-WdQ" id="Bu7-vU-kg2"/>
                 <outlet property="userIsActiveRadioButton" destination="dQw-jZ-xGK" id="QH7-ch-XLv"/>
@@ -348,16 +349,16 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" texturedBackground="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="335" y="390" width="511" height="294"/>
+            <rect key="contentRect" x="335" y="390" width="511" height="334"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <value key="minSize" type="size" width="280" height="122"/>
-            <value key="maxSize" type="size" width="9999" height="122"/>
+            <value key="minSize" type="size" width="280" height="334"/>
+            <value key="maxSize" type="size" width="9999" height="334"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="511" height="294"/>
+                <rect key="frame" x="0.0" y="0.0" width="511" height="334"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K1W-uM-L8Q">
-                        <rect key="frame" x="10" y="223" width="142" height="16"/>
+                        <rect key="frame" x="10" y="263" width="142" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Proxied device:" id="kXx-Cf-qRd">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -366,7 +367,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WDI-Cy-kGD">
-                        <rect key="frame" x="30" y="191" width="122" height="16"/>
+                        <rect key="frame" x="30" y="231" width="122" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Buffer size:" id="Xfs-Sf-N6a">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -375,7 +376,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vuz-aO-zYY">
-                        <rect key="frame" x="158" y="252" width="333" height="22"/>
+                        <rect key="frame" x="158" y="292" width="333" height="22"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="cHH-7S-0Po">
                             <font key="font" metaFont="system"/>
@@ -387,7 +388,7 @@
                         </connections>
                     </textField>
                     <comboBox verticalHuggingPriority="750" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tu4-jv-3Xp">
-                        <rect key="frame" x="158" y="185" width="203" height="26"/>
+                        <rect key="frame" x="158" y="225" width="203" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="czO-76-Qf9">
                             <font key="font" metaFont="system"/>
@@ -410,7 +411,7 @@
                         </connections>
                     </comboBox>
                     <comboBox verticalHuggingPriority="750" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8bM-6q-Jq9">
-                        <rect key="frame" x="158" y="217" width="336" height="26"/>
+                        <rect key="frame" x="158" y="257" width="336" height="26"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="uVe-kN-lbo">
                             <font key="font" metaFont="system"/>
@@ -422,7 +423,7 @@
                         </connections>
                     </comboBox>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RvA-0N-AJ5">
-                        <rect key="frame" x="10" y="159" width="142" height="16"/>
+                        <rect key="frame" x="10" y="199" width="142" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Proxy device is active:" id="VvD-u7-1hl">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -431,7 +432,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HsD-M9-H9y">
-                        <rect key="frame" x="10" y="255" width="142" height="16"/>
+                        <rect key="frame" x="10" y="295" width="142" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Proxy device name:" id="pmH-ny-HEp">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -440,7 +441,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dQw-jZ-xGK">
-                        <rect key="frame" x="157" y="104" width="313" height="18"/>
+                        <rect key="frame" x="157" y="144" width="313" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="radio" title="When user is not idle" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="esU-Cz-ZIH">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -451,7 +452,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qmk-xY-0ok">
-                        <rect key="frame" x="157" y="50" width="313" height="18"/>
+                        <rect key="frame" x="157" y="90" width="313" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="radio" title="Always" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Oyr-fA-rVo">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -462,7 +463,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcX-Yy-OAv">
-                        <rect key="frame" x="176" y="128" width="317" height="28"/>
+                        <rect key="frame" x="176" y="168" width="317" height="28"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" alignment="justified" title="Uses the least amount of CPU and battery power, but audio will occasionally get cut off as it starts playing" id="qvb-Im-ohV">
                             <font key="font" metaFont="smallSystem"/>
@@ -471,7 +472,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vzY-ng-OER">
-                        <rect key="frame" x="176" y="74" width="317" height="28"/>
+                        <rect key="frame" x="176" y="114" width="317" height="28"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" alignment="justified" title="Uses more CPU and battery power, but audio can only get cut off if it starts playing while the system is idle" id="BQi-ZR-QDr">
                             <font key="font" metaFont="smallSystem"/>
@@ -480,7 +481,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z61-bG-CaC">
-                        <rect key="frame" x="176" y="20" width="317" height="28"/>
+                        <rect key="frame" x="176" y="60" width="317" height="28"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" alignment="justified" title="Uses the most CPU and battery power, and prevents the system from sleeping. But audio will never be cut off." id="FIC-Ol-sTU">
                             <font key="font" metaFont="smallSystem"/>
@@ -489,7 +490,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="utN-wS-WdQ">
-                        <rect key="frame" x="157" y="158" width="203" height="18"/>
+                        <rect key="frame" x="157" y="198" width="203" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="radio" title="When proxied device is active" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="r2f-WB-mJx">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -497,6 +498,17 @@
                         </buttonCell>
                         <connections>
                             <action selector="proxiedDeviceIsActiveConditionSelected:" target="MLf-en-Bn8" id="ceM-6z-ofX"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hWu-01-chk">
+                        <rect key="frame" x="157" y="20" width="336" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Hide proxy device when target device is unavailable" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="hWu-01-cel">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="hideWhenUnavailableToggled:" target="MLf-en-Bn8" id="hWu-01-act"/>
                         </connections>
                     </button>
                 </subviews>

--- a/ProxyAudioDeviceSettings/WindowDelegate.h
+++ b/ProxyAudioDeviceSettings/WindowDelegate.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) IBOutlet NSButton *proxiedDeviceIsActiveRadioButton;
 @property(nonatomic, strong) IBOutlet NSButton *userIsActiveRadioButton;
 @property(nonatomic, strong) IBOutlet NSButton *alwaysRadioButton;
+@property(nonatomic, strong) IBOutlet NSButton *hideWhenUnavailableCheckbox;
 
 - (void)awakeFromNib;
 - (IBAction)deviceNameEntered:(id)sender;
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)proxiedDeviceIsActiveConditionSelected:(id)sender;
 - (IBAction)userIsActiveConditionSelected:(id)sender;
 - (IBAction)alwaysConditionSelected:(id)sender;
+- (IBAction)hideWhenUnavailableToggled:(id)sender;
 
 @end
 

--- a/ProxyAudioDeviceSettings/WindowDelegate.mm
+++ b/ProxyAudioDeviceSettings/WindowDelegate.mm
@@ -22,6 +22,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
     self.proxiedDeviceIsActiveRadioButton.enabled = NO;
     self.userIsActiveRadioButton.enabled = NO;
     self.alwaysRadioButton.enabled = NO;
+    self.hideWhenUnavailableCheckbox.enabled = NO;
     initializationAttemptInterval = 3;
     [self keepTryingToInitializeUntilSuccess];
 }
@@ -69,6 +70,9 @@ int onDevicesChanged(AudioObjectID inObjectID,
     self.proxiedDeviceIsActiveRadioButton.enabled = YES;
     self.userIsActiveRadioButton.enabled = YES;
     self.alwaysRadioButton.enabled = YES;
+    self.hideWhenUnavailableCheckbox.enabled = YES;
+    self.hideWhenUnavailableCheckbox.state =
+        [self currentHideWhenUnavailable] ? NSControlStateValueOn : NSControlStateValueOff;
 
     ProxyAudioDevice::ActiveCondition condition = [self currentOutputDeviceActiveCondition];
 
@@ -279,6 +283,29 @@ int onDevicesChanged(AudioObjectID inObjectID,
     self.proxiedDeviceIsActiveRadioButton.state = NSControlStateValueOff;
     self.userIsActiveRadioButton.state = NSControlStateValueOff;
     [self setCurrentOutputDeviceActiveCondition:ProxyAudioDevice::ActiveCondition::always];
+}
+
+// The driver reports this preference as "1" or "0" (see copyConfigurationValue
+// in ProxyAudioDevice.cpp). Anything non-"1" is treated as false.
+- (bool)currentHideWhenUnavailable {
+    AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
+    AudioDevice::setIdentifyValue(proxyAudioBox, -((SInt32)ProxyAudioDevice::ConfigType::deviceHideWhenUnavailable));
+    NSString *result = (__bridge_transfer NSString *)AudioDevice::copyObjectName(proxyAudioBox);
+
+    return [result intValue] != 0;
+}
+
+- (void)setCurrentHideWhenUnavailable:(bool)hide {
+    AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
+    AudioDevice::setObjectName(
+        proxyAudioBox,
+        (__bridge_retained CFStringRef)
+            [NSString stringWithFormat:@"outputDeviceHideWhenUnavailable=%d", hide ? 1 : 0]);
+}
+
+- (IBAction)hideWhenUnavailableToggled:(id)sender {
+    #pragma unused(sender)
+    [self setCurrentHideWhenUnavailable:(self.hideWhenUnavailableCheckbox.state == NSControlStateValueOn)];
 }
 
 @end

--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -3036,12 +3036,13 @@ OSStatus ProxyAudioDevice::GetDevicePropertyData(AudioServerPlugInDriverRef inDr
 
         case kAudioDevicePropertyIsHidden:
             //    This returns whether or not the device is visible to clients.
+            //    Hide the proxy device when the target output device is unavailable.
             FailWithAction(inDataSize < sizeof(UInt32),
                            theAnswer = kAudioHardwareBadPropertySizeError,
                            Done,
                            "GetDevicePropertyData: not enough space for the return value of "
                            "kAudioDevicePropertyIsHidden for the device");
-            *((UInt32 *)outData) = 0;
+            *((UInt32 *)outData) = outputDeviceReady ? 0 : 1;
             *outDataSize = sizeof(UInt32);
             break;
 
@@ -4845,6 +4846,15 @@ void ProxyAudioDevice::matchOutputDeviceSampleRateNoLock() {
     if (currentInputSampleRate == outputDevice.sampleRate) {
         outputDeviceReady = true;
         updateOutputDeviceStartedState();
+        
+        // Notify that the device is now visible since target device is available
+        ExecuteInAudioOutputThread(^() {
+            AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
+                                                     kAudioObjectPropertyScopeGlobal,
+                                                     kAudioObjectPropertyElementMaster};
+            gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
+        });
+
         return;
     }
 
@@ -4855,7 +4865,15 @@ void ProxyAudioDevice::matchOutputDeviceSampleRateNoLock() {
     
     outputDeviceReady = false;
     updateOutputDeviceStartedState();
-    
+
+    // Notify that device is now hidden during sample rate transition
+    ExecuteInAudioOutputThread(^() {
+        AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMaster};
+        gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
+    });
+
     resetInputData();
     outputDevice.updateStreamInfo();
 
@@ -4943,6 +4961,15 @@ void ProxyAudioDevice::deinitializeOutputDeviceNoLock() {
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock stopping device");
         outputDevice.stop();
         outputDeviceReady = false;
+        
+        // Notify that the device is now hidden since target device is unavailable
+        ExecuteInAudioOutputThread(^() {
+            AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
+                                                     kAudioObjectPropertyScopeGlobal,
+                                                     kAudioObjectPropertyElementMaster};
+            gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
+        });
+        
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock removing IO proc");
         outputDevice.destroyIOProc();
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock invalidating");

--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -570,6 +570,7 @@ OSStatus ProxyAudioDevice::Initialize(AudioServerPlugInDriverRef inDriver, Audio
     outputDeviceUID = copyOutputDeviceUIDFromStorage();
     outputDeviceBufferFrameSize = retrieveOutputDeviceBufferFrameSizeFromStorage();
     outputDeviceActiveCondition = retrieveOutputDeviceActiveConditionFromStorage();
+    outputDeviceHideWhenUnavailable = retrieveOutputDeviceHideWhenUnavailableFromStorage();
 
     //    calculate the host ticks per frame
     struct mach_timebase_info theTimeBaseInfo;
@@ -3036,13 +3037,18 @@ OSStatus ProxyAudioDevice::GetDevicePropertyData(AudioServerPlugInDriverRef inDr
 
         case kAudioDevicePropertyIsHidden:
             //    This returns whether or not the device is visible to clients.
-            //    Hide the proxy device when the target output device is unavailable.
+            //    Hide the proxy device when the target output device is unavailable,
+            //    but only if the user has opted in via the "hide when unavailable"
+            //    setting. By default the device always stays visible, which matches
+            //    the long-standing behavior for users that rely on the proxy device
+            //    as a stable target (e.g. for apps that don't react well to devices
+            //    appearing and disappearing).
             FailWithAction(inDataSize < sizeof(UInt32),
                            theAnswer = kAudioHardwareBadPropertySizeError,
                            Done,
                            "GetDevicePropertyData: not enough space for the return value of "
                            "kAudioDevicePropertyIsHidden for the device");
-            *((UInt32 *)outData) = outputDeviceReady ? 0 : 1;
+            *((UInt32 *)outData) = (outputDeviceHideWhenUnavailable && !outputDeviceReady) ? 1 : 0;
             *outDataSize = sizeof(UInt32);
             break;
 
@@ -4846,15 +4852,7 @@ void ProxyAudioDevice::matchOutputDeviceSampleRateNoLock() {
     if (currentInputSampleRate == outputDevice.sampleRate) {
         outputDeviceReady = true;
         updateOutputDeviceStartedState();
-        
-        // Notify that the device is now visible since target device is available
-        ExecuteInAudioOutputThread(^() {
-            AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
-                                                     kAudioObjectPropertyScopeGlobal,
-                                                     kAudioObjectPropertyElementMaster};
-            gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
-        });
-
+        notifyHiddenPropertyChanged();
         return;
     }
 
@@ -4862,17 +4860,10 @@ void ProxyAudioDevice::matchOutputDeviceSampleRateNoLock() {
     // NB: it's important that we not modify OutputDevice until it is no longer playing since
     // we're not using a locking mechanism on its attributes between this function and its IO
     // function.
-    
+
     outputDeviceReady = false;
     updateOutputDeviceStartedState();
-
-    // Notify that device is now hidden during sample rate transition
-    ExecuteInAudioOutputThread(^() {
-        AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
-                                                 kAudioObjectPropertyScopeGlobal,
-                                                 kAudioObjectPropertyElementMaster};
-        gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
-    });
+    notifyHiddenPropertyChanged();
 
     resetInputData();
     outputDevice.updateStreamInfo();
@@ -4961,15 +4952,8 @@ void ProxyAudioDevice::deinitializeOutputDeviceNoLock() {
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock stopping device");
         outputDevice.stop();
         outputDeviceReady = false;
-        
-        // Notify that the device is now hidden since target device is unavailable
-        ExecuteInAudioOutputThread(^() {
-            AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
-                                                     kAudioObjectPropertyScopeGlobal,
-                                                     kAudioObjectPropertyElementMaster};
-            gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
-        });
-        
+        notifyHiddenPropertyChanged();
+
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock removing IO proc");
         outputDevice.destroyIOProc();
         DebugMsg("ProxyAudio: deinitializeOutputDeviceNoLock invalidating");
@@ -5531,6 +5515,8 @@ void ProxyAudioDevice::parseConfigurationString(CFStringRef configString, Config
         action = ConfigType::deviceName;
     } else if (CFStringCompare(actionString, CFSTR("outputDeviceActiveCondition"), 0) == kCFCompareEqualTo) {
         action = ConfigType::deviceActiveCondition;
+    } else if (CFStringCompare(actionString, CFSTR("outputDeviceHideWhenUnavailable"), 0) == kCFCompareEqualTo) {
+        action = ConfigType::deviceHideWhenUnavailable;
     } else {
         return;
     }
@@ -5565,7 +5551,12 @@ void ProxyAudioDevice::setConfigurationValue(ConfigType type, CFStringRef value)
         case ConfigType::deviceActiveCondition:
             setOutputDeviceActiveCondition((ActiveCondition)CFStringGetIntValue(value));
             break;
-        
+
+        case ConfigType::deviceHideWhenUnavailable:
+            // Configurator passes "1" for true and "0" for false.
+            setOutputDeviceHideWhenUnavailable(CFStringGetIntValue(value) != 0);
+            break;
+
         default:
             break;
     }
@@ -5586,7 +5577,10 @@ CFStringRef ProxyAudioDevice::copyConfigurationValue(ConfigType type) {
 
         case ConfigType::deviceActiveCondition:
             return CFStringCreateWithFormat(NULL, NULL, CFSTR("%u"), outputDeviceActiveCondition);
-            
+
+        case ConfigType::deviceHideWhenUnavailable:
+            return CFStringCreateWithFormat(NULL, NULL, CFSTR("%u"), outputDeviceHideWhenUnavailable ? 1 : 0);
+
         default:
             return nullptr;
     }
@@ -5803,6 +5797,54 @@ void ProxyAudioDevice::setOutputDeviceActiveCondition(ActiveCondition newActiveC
         CFNumberSmartRef newActiveConditionRef = CFNumberCreate(NULL, kCFNumberSInt32Type, &newActiveCondition);
         gPlugIn_Host->WriteToStorage(gPlugIn_Host, CFSTR("outputDeviceActiveCondition"), newActiveConditionRef);
     }
+}
+
+bool ProxyAudioDevice::retrieveOutputDeviceHideWhenUnavailableFromStorage() {
+    DebugMsg("ProxyAudio: retrieveOutputDeviceHideWhenUnavailableFromStorage");
+
+    if (!gPlugIn_Host) {
+        DebugMsg("ProxyAudio: retrieveOutputDeviceHideWhenUnavailableFromStorage no plugin host");
+        return kOutputDeviceDefaultHideWhenUnavailable;
+    }
+
+    CFPropertyListSmartRef data;
+    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("outputDeviceHideWhenUnavailable"), &data);
+
+    if (data == NULL || CFGetTypeID(data) != CFBooleanGetTypeID()) {
+        DebugMsg("ProxyAudio: retrieveOutputDeviceHideWhenUnavailableFromStorage finished returning default value");
+        return kOutputDeviceDefaultHideWhenUnavailable;
+    }
+
+    return CFBooleanGetValue(CFBooleanRef(CFPropertyListRef(data)));
+}
+
+void ProxyAudioDevice::setOutputDeviceHideWhenUnavailable(bool newHideWhenUnavailable) {
+    {
+        CAMutex::Locker locker(&stateMutex);
+        outputDeviceHideWhenUnavailable = newHideWhenUnavailable;
+        gPlugIn_Host->WriteToStorage(gPlugIn_Host,
+                                     CFSTR("outputDeviceHideWhenUnavailable"),
+                                     newHideWhenUnavailable ? kCFBooleanTrue : kCFBooleanFalse);
+    }
+
+    // Toggling the setting changes the effective hidden state, so let the host
+    // re-query kAudioDevicePropertyIsHidden immediately instead of waiting for
+    // the next device-availability transition.
+    notifyHiddenPropertyChanged();
+}
+
+// Tell the host to re-read kAudioDevicePropertyIsHidden. We always notify,
+// even when the "hide when unavailable" setting is off, so that toggling the
+// setting or having the target device come and go is picked up immediately.
+// With the setting off the getter always returns 0, so the notification is
+// harmless (the host just sees the same value it already had).
+void ProxyAudioDevice::notifyHiddenPropertyChanged() {
+    ExecuteInAudioOutputThread(^() {
+        AudioObjectPropertyAddress theAddress = {kAudioDevicePropertyIsHidden,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMaster};
+        gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Device, 1, &theAddress);
+    });
 }
 
 #pragma mark Other stuff!

--- a/proxyAudioDevice/ProxyAudioDevice.h
+++ b/proxyAudioDevice/ProxyAudioDevice.h
@@ -29,10 +29,20 @@ enum {
 #define kOutputDeviceDefaultBufferFrameSize 512
 #define kOutputDeviceMinBufferFrameSize 4
 #define kOutputDeviceDefaultActiveCondition ActiveCondition::userActive
+// Default to false so the proxy device stays visible even when the target is
+// unavailable. This preserves the long-standing behavior for existing users.
+#define kOutputDeviceDefaultHideWhenUnavailable false
 
 class ProxyAudioDevice {
   public:
-    enum class ConfigType { none, outputDevice, outputDeviceBufferFrameSize, deviceName, deviceActiveCondition };
+    enum class ConfigType {
+        none,
+        outputDevice,
+        outputDeviceBufferFrameSize,
+        deviceName,
+        deviceActiveCondition,
+        deviceHideWhenUnavailable
+    };
     enum class ActiveCondition { proxiedDeviceActive = 0, userActive = 1, always = 2 };
 
     ProxyAudioDevice() : inputIOIsActive(false) {};
@@ -98,6 +108,9 @@ class ProxyAudioDevice {
     void setOutputDeviceBufferFrameSize(UInt32 size);
     ActiveCondition retrieveOutputDeviceActiveConditionFromStorage();
     void setOutputDeviceActiveCondition(ActiveCondition newActiveCondition);
+    bool retrieveOutputDeviceHideWhenUnavailableFromStorage();
+    void setOutputDeviceHideWhenUnavailable(bool newHideWhenUnavailable);
+    void notifyHiddenPropertyChanged();
 
     static ProxyAudioDevice *deviceForDriver(void *inDriver);
 
@@ -497,6 +510,7 @@ class ProxyAudioDevice {
     Float64 outputAccumulatedRateRatio = 0.0;
     UInt64 outputAccumulatedRateRatioSamples = 0;
     ActiveCondition outputDeviceActiveCondition = ActiveCondition::userActive;
+    bool outputDeviceHideWhenUnavailable = kOutputDeviceDefaultHideWhenUnavailable;
     
     UInt32 gPlugIn_RefCount = 0;
     AudioServerPlugInHostRef gPlugIn_Host = NULL;


### PR DESCRIPTION
## Summary

This PR builds on #61 by @seungwoochoe to address the feedback from @briankendall: the auto-hide behavior is useful but needs to be opt-in so it does not change behavior for existing users who rely on the proxy device as a stable, always-visible target.

Two commits, to keep the two authors' work cleanly separated:

1. **@seungwoochoe's PR #61, cherry-picked as-is** — preserves original authorship.
2. **New preference `outputDeviceHideWhenUnavailable`** — defaults to `false`, so behavior matches the current release for anyone who upgrades without opening Settings.

## Settings app mockup

The new checkbox appears at the bottom of the existing Settings window, unchecked by default:

![Settings app mockup showing new "Hide proxy device when target device is unavailable" checkbox at the bottom, unchecked](https://raw.githubusercontent.com/mcg1969/proxy-audio-device/pr-assets/settings-mockup.png)

*Note: this is a programmatic mockup rendered from the xib's frame coordinates; native macOS rendering will look tighter (system fonts, bezel gradients, vibrancy). Positions and labels are faithful to what the actual xib produces.*

## Changes

* New persisted driver preference `outputDeviceHideWhenUnavailable`, stored via `gPlugIn_Host->WriteToStorage` as a `CFBoolean`, following the same pattern as `outputDeviceActiveCondition`.
* `kAudioDevicePropertyIsHidden` getter now returns `1` only when the pref is on AND the target device is not ready — default (off) preserves the prior always-visible behavior.
* Refactored PR #61's three duplicated `PropertiesChanged(kAudioDevicePropertyIsHidden)` notification blocks into a single `notifyHiddenPropertyChanged()` helper.
* New checkbox in the Settings app ("Hide proxy device when target device is unavailable"), wired through the same configurator round-trip used by the existing active-condition radio buttons.
* Window height in `MainMenu.xib` extended to accommodate the new control.

## Rationale for the default

From @briankendall's review on #61:

> One of the major use cases for the proxy device is having a device that *doesn't* disappear but can still be used to consistently play to the right device, for apps that don't properly handle changes to available audio devices.

Defaulting the new pref to `false` preserves that behavior for existing installations; users who want the new auto-hide behavior can opt in via the Settings app.

## Test plan

* [x] Build `ProxyAudioDevice` target: succeeds
* [x] Build `Proxy Audio Device Settings` target: succeeds
* [x] Install driver, open Settings app — new checkbox appears, defaults to off
* [x] With checkbox **off**: disconnect/reconnect target device → proxy device stays visible (existing behavior)
* [x] With checkbox **on**: disconnect target device → proxy device hides; reconnect → proxy device reappears (PR #61 behavior)
* [x] Toggling the checkbox while the target is disconnected takes effect immediately (does not require a device-availability event)
* [x] Preference persists across reboots / `coreaudiod` restarts

## Disclosure

This change was developed with assistance from Claude (Anthropic's AI coding assistant). The `Co-Authored-By: Claude Opus 4.7` trailer on commit 2 reflects this.
