### PR TITLE
Tolerate USB port changes and retry missing output devices

### DIFF
--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -24,15 +24,56 @@ std::string CFStringToStdString(CFStringRef s) {
     if (!s) {
         return std::string("<null>");
     }
-    
+
     char *buffer;
     size_t length = CFStringGetLength(s) + 1;
     buffer = new char[length];
     CFStringGetCString(s, buffer, length, kCFStringEncodingUTF8);
     std::string result(buffer);
     delete buffer;
-    
+
     return result;
+}
+
+// Splits a string on ':' and returns the components.
+static std::vector<std::string> splitOnColon(const std::string &s) {
+    std::vector<std::string> result;
+    size_t start = 0;
+    size_t pos;
+    while ((pos = s.find(':', start)) != std::string::npos) {
+        result.push_back(s.substr(start, pos - start));
+        start = pos + 1;
+    }
+    result.push_back(s.substr(start));
+    return result;
+}
+
+// Returns true iff `candidate` represents the same physical USB audio device as
+// `target`, ignoring the USB location ID. macOS embeds the location ID into the
+// synthesized UID for AppleUSBAudioEngine devices that have no serial number,
+// which means plugging the same device into a different USB/Thunderbolt port
+// changes its UID. We tolerate that by matching every other UID component
+// exactly.
+//
+// The UID format we accept (exactly 5 ':'-separated components) is:
+//     AppleUSBAudioEngine:<Manufacturer>:<Product>:<LocationID>:<Stream#>
+//
+// Only the LocationID field is allowed to differ. We require an exact match on
+// the prefix, manufacturer, product, and stream-number fields, which is strict
+// enough that distinct devices from the same vendor still won't be confused.
+static bool isSameUSBDeviceDifferentPort(CFStringRef target, CFStringRef candidate) {
+    if (!target || !candidate) {
+        return false;
+    }
+    std::vector<std::string> t = splitOnColon(CFStringToStdString(target));
+    std::vector<std::string> c = splitOnColon(CFStringToStdString(candidate));
+    if (t.size() != 5 || c.size() != 5) return false;
+    if (t[0] != "AppleUSBAudioEngine" || c[0] != "AppleUSBAudioEngine") return false;
+    if (t[1] != c[1]) return false;
+    if (t[2] != c[2]) return false;
+    // t[3] / c[3] is the LocationID and is allowed to differ.
+    if (t[4] != c[4]) return false;
+    return true;
 }
 
 #pragma mark The Interface
@@ -4665,20 +4706,23 @@ AudioDevice ProxyAudioDevice::findTargetOutputAudioDevice() {
     DebugMsg("ProxyAudio: findTargetOutputAudioDevice");
     std::vector<AudioObjectID> devices = AudioDevice::allAudioDevices();
     CFStringSmartRef currentOutputDeviceUID;
-    
+
     {
         CAMutex::Locker locker(&stateMutex);
-        
+
         if (!outputDeviceUID) {
             DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, output device UID is null");
             return AudioDevice();
         }
-        
+
         currentOutputDeviceUID = CFStringCreateCopy(NULL, outputDeviceUID);
     }
-    
+
     DebugMsg("ProxyAudio: findTargetOutputAudioDevice target UID: %s", CFStringToStdString(currentOutputDeviceUID).c_str());
-    
+
+    // First pass: look for an exact UID match. This is the common path.
+    AudioObjectID fallbackMatch = kAudioObjectUnknown;
+
     for (AudioObjectID device : devices) {
         AudioObjectPropertyAddress propertyAddress = {
             kAudioDevicePropertyDeviceUID, kAudioObjectPropertyScopeOutput, kAudioObjectPropertyElementMaster};
@@ -4692,11 +4736,30 @@ AudioDevice ProxyAudioDevice::findTargetOutputAudioDevice() {
                 DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, found output device");
                 return AudioDevice(device);
             }
+
+            // Note any candidate that looks like the same physical USB device
+            // plugged into a different port. We don't return it yet -- we want
+            // the exact-match pass to win if there is one.
+            if (fallbackMatch == kAudioObjectUnknown
+                && isSameUSBDeviceDifferentPort(currentOutputDeviceUID, uid)) {
+                fallbackMatch = device;
+            }
         }
     }
 
-    DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, not not find output device");
-    
+    // Second pass result: same physical USB device on a different port.
+    // Common case: a Thunderbolt dock plugged into a different port on the Mac.
+    // We deliberately do NOT update outputDeviceUID here; if the user really
+    // wants the new UID persisted, they can re-pick the device from the
+    // settings app. Leaving the stored UID alone means that returning to the
+    // original port will keep working without surprise.
+    if (fallbackMatch != kAudioObjectUnknown) {
+        DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, matched same USB device on a different port");
+        return AudioDevice(fallbackMatch);
+    }
+
+    DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, did not find output device");
+
     return AudioDevice();
 }
 
@@ -4889,11 +4952,16 @@ void ProxyAudioDevice::matchOutputDeviceSampleRate()
 
 void ProxyAudioDevice::setupTargetOutputDevice() {
     DebugMsg("ProxyAudio: setupTargetOutputDevice");
+
+    // Cancel any pending retry from a previous failed setup. Anything
+    // scheduled before this call will see a different generation and skip.
+    int generation = ++targetDeviceSearchGeneration;
+
     AudioDevice newOutputDevice = findTargetOutputAudioDevice();
 
     DebugMsg("ProxyAudio: setupTargetOutputDevice newOutputDevice: %d", newOutputDevice.id);
     CAMutex::Locker locker(outputDeviceMutex);
-    
+
     if (outputDevice.isValid() && outputDevice.id == newOutputDevice.id
         && outputDevice.bufferFrameSize == outputDeviceBufferFrameSize) {
         DebugMsg("ProxyAudio: setupTargetOutputDevice no change in device");
@@ -4926,7 +4994,34 @@ void ProxyAudioDevice::setupTargetOutputDevice() {
         matchOutputDeviceSampleRateNoLock();
     } else {
         syslog(LOG_WARNING, "ProxyAudio: setupTargetOutputDevice could not find output device");
+        // The device-list listener will fire when the system enumerates devices
+        // again, but some real-world cases (sleep/wake, transient Bluetooth
+        // dropouts) don't reliably trigger it. Schedule a periodic retry so we
+        // can recover on our own if the target device reappears.
+        scheduleTargetDeviceRetry(generation);
     }
+}
+
+void ProxyAudioDevice::scheduleTargetDeviceRetry(int generation) {
+    // 5-second retry interval: long enough that a Bluetooth or USB hiccup will
+    // typically have resolved, short enough that the user won't be staring at
+    // a silent system for long.
+    const uint64_t kRetryDelayNs = 5ull * NSEC_PER_SEC;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kRetryDelayNs),
+                   AudioOutputDispatchQueue(),
+                   ^() {
+                       // If another setup ran in the meantime (user picked a
+                       // different device, or device-list listener fired), our
+                       // generation is stale and we should bow out -- the new
+                       // call already handled or rescheduled retry.
+                       if (generation != targetDeviceSearchGeneration.load()) {
+                           DebugMsg("ProxyAudio: target device retry skipped, generation stale");
+                           return;
+                       }
+                       DebugMsg("ProxyAudio: target device retry firing");
+                       setupTargetOutputDevice();
+                   });
 }
 
 void ProxyAudioDevice::initializeOutputDevice() {

--- a/proxyAudioDevice/ProxyAudioDevice.h
+++ b/proxyAudioDevice/ProxyAudioDevice.h
@@ -73,6 +73,7 @@ class ProxyAudioDevice {
                             const AudioObjectPropertyAddress *inAddresses);
     void setupAudioDevicesListener();
     void setupTargetOutputDevice();
+    void scheduleTargetDeviceRetry(int generation);
     void initializeOutputDevice();
     void deinitializeOutputDeviceNoLock();
     void deinitializeOutputDevice();
@@ -511,6 +512,10 @@ class ProxyAudioDevice {
     UInt64 outputAccumulatedRateRatioSamples = 0;
     ActiveCondition outputDeviceActiveCondition = ActiveCondition::userActive;
     bool outputDeviceHideWhenUnavailable = kOutputDeviceDefaultHideWhenUnavailable;
+
+    // Bumped on every entry to setupTargetOutputDevice so any pending retry
+    // block from a prior failed setup will see a stale generation and bail out.
+    std::atomic<int> targetDeviceSearchGeneration{0};
     
     UInt32 gPlugIn_RefCount = 0;
     AudioServerPlugInHostRef gPlugIn_Host = NULL;


### PR DESCRIPTION
> **Disclosure:** Claude (Anthropic's AI coding assistant) was used in the development of this PR. The author has reviewed and tested the change.

## Summary

My audio device is the digital audio output from my CalDigit Thunderbolt dock. I was finding that sometimes, when I plug my dock back in, Proxy Audio Device wasn't finding the device anymore. I expected #61 / #70 to fix that, but it didn't... And I was finding the symptom was not consistent. Sometimes it found the device, sometimes it didn't.

It turns out that the randomness was generated by me. When I plug in the dock I'm doing it by feel, and I was alternating randomly between the two USB-C ports on the left/blind side of my MBP. If I plugged it into the *other* port compared to the one I used to set the ProxyAudioDevice settings, that's when it lost track of the device.

This PR makes the driver more robust about retaining its target output device when the device is briefly unavailable or its UID has changed because of a USB port swap.

### The problem

The driver remembers its target output device by UID, but for USB audio devices that don't expose a serial number (common in Thunderbolt docks), macOS synthesizes the UID by embedding the USB *location ID*:

```
AppleUSBAudioEngine:<vendor>:<product>:<location-id>:<stream>
```

Plugging the same device into a different physical port on the Mac changes the location ID, which changes the UID. The driver would fail to find the device and stay silent until the user manually re-selected it from the Settings app.

This was also a contributing factor to the issue described in PR #61: when the dock came back on a different port, the proxy audio device remained "selected" but was effectively pointing at nothing. (With the new "hide when unavailable" preference from #70 turned on, the symptom shifted from "no audio" to "Proxy Audio is missing from the system audio list".)

### The fix

Two complementary changes, both in the driver:

**1. Tolerant USB UID matching in `findTargetOutputAudioDevice`.** When the exact UID match fails, a second pass looks for a device whose UID matches in every component except the location ID. Only `AppleUSBAudioEngine` UIDs of exactly the expected 5-component shape are eligible, so devices from the same vendor with different products won't be confused. The stored UID is intentionally *not* overwritten on a port-swap match — returning to the original port still just works.

**2. Periodic retry when the target device can't be found.** When `setupTargetOutputDevice` finds no match, it now schedules a retry every 5 seconds via the existing audio-output dispatch queue. The device-list listener already covers most reconnections, but sleep/wake and transient Bluetooth dropouts don't always fire it. A generation counter ensures any in-flight retry from a previous failed setup is canceled when a new setup runs.

## Test plan

Tested locally on macOS 26.4 (Apple Silicon) with a CalDigit Thunderbolt 3 Dock with no USB serial number. Even though I only ever swapped between two physical USB-C ports, the dock's location ID came back as three distinct values across the testing session — further evidence that the UID can't be relied on as a stable handle for the same device:

```
AppleUSBAudioEngine:CalDigit, Inc.:CalDigit Thunderbolt 3 Audio:20200000:1
AppleUSBAudioEngine:CalDigit, Inc.:CalDigit Thunderbolt 3 Audio:21200000:1
AppleUSBAudioEngine:CalDigit, Inc.:CalDigit Thunderbolt 3 Audio:22200000:1
```

* [x] Build cleanly with `xcodebuild -configuration Release`.
* [x] Driver loads after install + `killall coreaudiod`.
* [x] Proxy Audio Device remains present and audible after dock is moved to a different USB-C port (audio handed off seamlessly without user intervention).
* [x] After dock is fully unplugged, audio falls back to another device. When dock is plugged back in, Proxy Audio reconnects automatically within a few seconds (retry path).
* [x] Stored UID is preserved across port-swap matches — returning to the original port works without re-selection.

## Notes

* Behavior is unchanged for devices whose UIDs are stable across reconnections (devices with serial numbers, non-USB devices, etc.).
* No change to the settings app.
* No change to user-facing preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
