### PR TITLE
Add device priority chain with automatic failover

### DIFF
--- a/ProxyAudioDeviceSettings/WindowDelegate.h
+++ b/ProxyAudioDeviceSettings/WindowDelegate.h
@@ -2,14 +2,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WindowDelegate : NSObject
+@interface WindowDelegate : NSObject <NSTableViewDataSource, NSTableViewDelegate>
 @property(nonatomic, strong) IBOutlet NSTextField *deviceNameTextField;
+// Legacy single-device combo box. Kept so the existing XIB connection stays
+// valid, but hidden at runtime and replaced by the priority list table below.
 @property(nonatomic, strong) IBOutlet NSComboBox *outputDeviceComboBox;
 @property(nonatomic, strong) IBOutlet NSComboBox *bufferSizeComboBox;
 @property(nonatomic, strong) IBOutlet NSButton *proxiedDeviceIsActiveRadioButton;
 @property(nonatomic, strong) IBOutlet NSButton *userIsActiveRadioButton;
 @property(nonatomic, strong) IBOutlet NSButton *alwaysRadioButton;
 @property(nonatomic, strong) IBOutlet NSButton *hideWhenUnavailableCheckbox;
+
+// Priority list UI, built programmatically (see setupPriorityListUI).
+@property(nonatomic, strong) NSTableView *priorityTableView;
+@property(nonatomic, strong) NSButton *addDeviceButton;
+@property(nonatomic, strong) NSButton *removeDeviceButton;
+@property(nonatomic, strong) NSButton *moveUpButton;
+@property(nonatomic, strong) NSButton *moveDownButton;
+@property(nonatomic, strong) NSButton *autoFailbackCheckbox;
 
 - (void)awakeFromNib;
 - (IBAction)deviceNameEntered:(id)sender;
@@ -19,6 +29,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)userIsActiveConditionSelected:(id)sender;
 - (IBAction)alwaysConditionSelected:(id)sender;
 - (IBAction)hideWhenUnavailableToggled:(id)sender;
+
+// Priority list actions.
+- (void)addDeviceClicked:(id)sender;
+- (void)removeDeviceClicked:(id)sender;
+- (void)moveDeviceUpClicked:(id)sender;
+- (void)moveDeviceDownClicked:(id)sender;
+- (void)autoFailbackToggled:(id)sender;
 
 @end
 

--- a/ProxyAudioDeviceSettings/WindowDelegate.mm
+++ b/ProxyAudioDeviceSettings/WindowDelegate.mm
@@ -9,9 +9,29 @@ int onDevicesChanged(AudioObjectID inObjectID,
                      const AudioObjectPropertyAddress *inAddresses,
                      void *inClientData);
 
+// Persisted in the settings app's own preferences: a UID -> display name map so
+// we can show a friendly name for devices that are currently disconnected (the
+// driver only stores UIDs; CoreAudio can't name a device that isn't present).
+static NSString *const kNameCacheKey = @"deviceNameCacheByUID";
+
+// Column identifiers for the priority table.
+static NSString *const kDeviceColumnID = @"device";
+static NSString *const kStatusColumnID = @"status";
+
+// --- Programmatic layout constants (tweak here to adjust the priority list UI) ---
+// Extra height added to the window to make room for the priority list, in points.
+static const CGFloat kPriorityUIExtraHeight = 150.0;
+static const CGFloat kPriorityListLeftX = 158.0;
+static const CGFloat kPriorityListWidth = 336.0;
+
 @implementation WindowDelegate {
-    std::vector<AudioDeviceID> currentDeviceList;
+    NSMutableArray<NSString *> *priorityUIDs;
+    NSDictionary<NSString *, NSString *> *connectedNamesByUID;
+    NSString *activeUID;
+    bool priorityUIBuilt;
     int initializationAttemptInterval;
+    NSTimer *refreshTimer;
+    NSString *lastDisplaySignature;
 }
 
 - (void)awakeFromNib {
@@ -23,6 +43,9 @@ int onDevicesChanged(AudioObjectID inObjectID,
     self.userIsActiveRadioButton.enabled = NO;
     self.alwaysRadioButton.enabled = NO;
     self.hideWhenUnavailableCheckbox.enabled = NO;
+    priorityUIDs = [NSMutableArray array];
+    connectedNamesByUID = @{};
+    priorityUIBuilt = false;
     initializationAttemptInterval = 3;
     [self keepTryingToInitializeUntilSuccess];
 }
@@ -33,7 +56,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
     // a few seconds. We're initially waiting three seconds because that seems to work. Using less time
     // can actually cause the audio server to crash, so we want to be careful not to query it too often!
     bool success = [self initialize];
-    
+
     if (!success) {
         NSLog(@"NB: failed to initialize, will try again in a sec...");
         [NSTimer scheduledTimerWithTimeInterval:initializationAttemptInterval target:self selector:@selector(keepTryingToInitializeUntilSuccess) userInfo:nil repeats:NO];
@@ -46,26 +69,29 @@ int onDevicesChanged(AudioObjectID inObjectID,
     if (![self setCurrentProcessAsConfigurator]) {
         return false;
     }
-    
+
     self.deviceNameTextField.stringValue = [self currentDeviceName];
-    
+
     if (![self proxyAudioDeviceAvailable]) {
         // It's expected that we won't find the Proxy Audio Device if it's not installed, so this
         // technically isn't a failure case where we'd want to try initializing the app again.
         return true;
     }
-    
-    if (![self refreshOutputDevices]) {
+
+    [self setupPriorityListUI];
+
+    if (![self refreshPriorityList]) {
         return false;
     }
-    
+
     if (![self setupListenerForCurrentAudioDevices]) {
         return false;
     }
-    
+
+    [self startRefreshTimer];
+
     [self.bufferSizeComboBox selectItemWithObjectValue:[self currentOutputDeviceBufferFrameSize]];
     self.deviceNameTextField.enabled = YES;
-    self.outputDeviceComboBox.enabled = YES;
     self.bufferSizeComboBox.enabled = YES;
     self.proxiedDeviceIsActiveRadioButton.enabled = YES;
     self.userIsActiveRadioButton.enabled = YES;
@@ -73,6 +99,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
     self.hideWhenUnavailableCheckbox.enabled = YES;
     self.hideWhenUnavailableCheckbox.state =
         [self currentHideWhenUnavailable] ? NSControlStateValueOn : NSControlStateValueOff;
+    self.autoFailbackCheckbox.state = [self currentAutoFailback] ? NSControlStateValueOn : NSControlStateValueOff;
 
     ProxyAudioDevice::ActiveCondition condition = [self currentOutputDeviceActiveCondition];
 
@@ -95,19 +122,19 @@ int onDevicesChanged(AudioObjectID inObjectID,
 
 - (bool)setCurrentProcessAsConfigurator {
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
-    
+
     if (proxyAudioBox == kAudioObjectUnknown) {
         NSLog(@"Error: unable to find proxy audio device");
         // It's expected that we won't find the Proxy Audio Device if it's not installed, so this
         // technically isn't a failure case where we'd want to try initializing the app again.
         return true;
     }
-    
+
     if (!AudioDevice::setIdentifyValue(proxyAudioBox, getpid())) {
         NSLog(@"Error: unable to set current process as configurator");
         return false;
     }
-    
+
     return true;
 }
 
@@ -118,7 +145,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
 #pragma unused(inObjectID, inNumberAddresses, inAddresses)
     dispatch_async(dispatch_get_main_queue(), ^{
         WindowDelegate *delegate = (__bridge WindowDelegate *)inClientData;
-        [delegate refreshOutputDevices];
+        [delegate refreshPriorityList];
     });
 
     return noErr;
@@ -134,7 +161,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
         NSLog(@"Error: could not set up listener for audio devices changing");
         return false;
     }
-    
+
     return true;
 }
 
@@ -146,7 +173,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setIdentifyValue(proxyAudioBox, -((SInt32)ProxyAudioDevice::ConfigType::deviceName));
     NSString *result = (__bridge_transfer NSString *)AudioDevice::copyObjectName(proxyAudioBox);
-    
+
     return result ? result : NSLocalizedString(@"< Proxy Audio Device not found >", nil);
 }
 
@@ -154,7 +181,7 @@ int onDevicesChanged(AudioObjectID inObjectID,
 #pragma unused(sender)
     NSString *newName = [self.deviceNameTextField.stringValue
         stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    
+
     if (newName.length == 0) {
         self.deviceNameTextField.stringValue = [self currentDeviceName];
         return;
@@ -162,73 +189,416 @@ int onDevicesChanged(AudioObjectID inObjectID,
 
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setObjectName(proxyAudioBox,
-                               (__bridge_retained CFStringRef)[NSString stringWithFormat:@"deviceName=%@", newName]);
+                               (__bridge CFStringRef)[NSString stringWithFormat:@"deviceName=%@", newName]);
 }
 
-- (AudioDeviceID)currentOutputDevice {
+#pragma mark - Configuration channel helpers
+
+// Reads a configuration value from the driver using the identify-value hack:
+// set the box's identify property to the negative ConfigType, then read back its
+// name property. Returns nil if nothing was returned.
+- (NSString *)readConfigValueForType:(ProxyAudioDevice::ConfigType)type {
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
-    AudioDevice::setIdentifyValue(proxyAudioBox, -((SInt32)ProxyAudioDevice::ConfigType::outputDevice));
-    NSString *outputDeviceUID = (__bridge_transfer NSString *)AudioDevice::copyObjectName(proxyAudioBox);
-    
-    return AudioDevice::audioDeviceIDForDeviceUID((__bridge_retained CFStringRef)outputDeviceUID);
+    AudioDevice::setIdentifyValue(proxyAudioBox, -((SInt32)type));
+    return (__bridge_transfer NSString *)AudioDevice::copyObjectName(proxyAudioBox);
 }
 
-- (bool)refreshOutputDevices {
-    bool success = false;
-    [self.outputDeviceComboBox removeAllItems];
-    currentDeviceList = AudioDevice::devicesWithOutputCapabilitiesThatAreNotProxyAudioDevice();
-    AudioDeviceID outputDevice = [self currentOutputDevice];
-    
-    for (unsigned int i = 0; i < currentDeviceList.size(); ++i) {
-        NSString *deviceName = (__bridge_transfer NSString *)AudioDevice::copyObjectName(currentDeviceList[i]);
-        
-        if (!deviceName) {
-            NSLog(@"Note: got null device name for audio device with device with ID: %d", currentDeviceList[i]);
-            continue;
-        }
-        
-        [self.outputDeviceComboBox addItemWithObjectValue:deviceName];
-        
-        if (outputDevice == currentDeviceList[i]) {
-            [self.outputDeviceComboBox selectItemAtIndex:i];
-        }
-        
-        success = true;
-    }
-    
-    if (!success) {
-        NSLog(@"Error: failed to get any information about current output devices!");
-    }
-    
-    return success;
+// Writes a "key=value" configuration string to the driver. __bridge (not
+// __bridge_retained) is correct here: setObjectName only needs the string for
+// the duration of the synchronous call, so handing it a +1 reference would leak.
+- (void)writeConfigString:(NSString *)keyValue {
+    AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
+    AudioDevice::setObjectName(proxyAudioBox, (__bridge CFStringRef)keyValue);
 }
 
+#pragma mark - Priority list model
+
+- (NSArray<NSString *> *)readPriorityUIDsFromDriver {
+    NSString *blob = [self readConfigValueForType:ProxyAudioDevice::ConfigType::outputDevicePriorityList];
+
+    if (blob.length == 0) {
+        return @[];
+    }
+
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+
+    for (NSString *uid in [blob componentsSeparatedByString:@"\n"]) {
+        if (uid.length > 0) {
+            [result addObject:uid];
+        }
+    }
+
+    return result;
+}
+
+- (void)writePriorityUIDsToDriver {
+    NSString *blob = [priorityUIDs componentsJoinedByString:@"\n"];
+    [self writeConfigString:[NSString stringWithFormat:@"outputDevicePriorityList=%@", blob]];
+}
+
+- (NSString *)currentActiveOutputDeviceUID {
+    NSString *uid = [self readConfigValueForType:ProxyAudioDevice::ConfigType::currentActiveOutputDevice];
+    return uid.length > 0 ? uid : nil;
+}
+
+- (BOOL)currentAutoFailback {
+    NSString *value = [self readConfigValueForType:ProxyAudioDevice::ConfigType::outputDeviceAutoFailback];
+    return value.intValue != 0;
+}
+
+#pragma mark - Display name cache
+
+- (NSString *)cachedNameForUID:(NSString *)uid {
+    NSDictionary *cache = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kNameCacheKey];
+    return cache[uid];
+}
+
+- (void)cacheName:(NSString *)name forUID:(NSString *)uid {
+    if (name.length == 0 || uid.length == 0) {
+        return;
+    }
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSMutableDictionary *cache = [([defaults dictionaryForKey:kNameCacheKey] ?: @{}) mutableCopy];
+
+    if ([cache[uid] isEqualToString:name]) {
+        return;
+    }
+
+    cache[uid] = name;
+    [defaults setObject:cache forKey:kNameCacheKey];
+}
+
+- (NSString *)displayNameForUID:(NSString *)uid {
+    NSString *liveName = connectedNamesByUID[uid];
+
+    if (liveName.length > 0) {
+        return liveName;
+    }
+
+    NSString *cachedName = [self cachedNameForUID:uid];
+
+    if (cachedName.length > 0) {
+        return cachedName;
+    }
+
+    return uid;
+}
+
+// Returns the UIDs and names of currently-connected output devices (excluding
+// the proxy device), and refreshes the display-name cache as a side effect.
+- (NSDictionary<NSString *, NSString *> *)connectedOutputDeviceNamesByUID {
+    NSMutableDictionary<NSString *, NSString *> *result = [NSMutableDictionary dictionary];
+    std::vector<AudioDeviceID> devices = AudioDevice::devicesWithOutputCapabilitiesThatAreNotProxyAudioDevice();
+
+    for (AudioDeviceID device : devices) {
+        NSString *uid = (__bridge_transfer NSString *)AudioDevice::copyDeviceUID(device);
+        NSString *name = (__bridge_transfer NSString *)AudioDevice::copyObjectName(device);
+
+        if (uid.length > 0 && name.length > 0) {
+            result[uid] = name;
+            [self cacheName:name forUID:uid];
+        }
+    }
+
+    return result;
+}
+
+#pragma mark - Priority list refresh
+
+// Some devices (USB/Bluetooth) stay enumerated but report not-alive on
+// disconnect, which does not change kAudioHardwarePropertyDevices and so fires no
+// device-list notification. A light poll keeps the status column and active
+// marker honest regardless of which notifications the system sends.
+- (void)startRefreshTimer {
+    if (refreshTimer) {
+        return;
+    }
+
+    refreshTimer = [NSTimer scheduledTimerWithTimeInterval:1.5
+                                                    target:self
+                                                  selector:@selector(pollRefresh)
+                                                  userInfo:nil
+                                                   repeats:YES];
+}
+
+- (void)pollRefresh {
+    // Only do the work while the settings window is actually on screen.
+    if (self.priorityTableView.window.isVisible) {
+        [self refreshPriorityList];
+    }
+}
+
+// Mirrors the driver's definition of "available": present in the system AND
+// reporting itself as alive. Keeps the app's status column in agreement with the
+// device the driver actually routes to.
+- (BOOL)isUIDAvailable:(NSString *)uid {
+    if (uid.length == 0) {
+        return NO;
+    }
+
+    AudioDeviceID device = AudioDevice::audioDeviceIDForDeviceUID((__bridge CFStringRef)uid);
+
+    if (device == kAudioObjectUnknown) {
+        return NO;
+    }
+
+    AudioObjectPropertyAddress aliveAddress = {
+        kAudioDevicePropertyDeviceIsAlive, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster};
+    UInt32 alive = 0;
+    UInt32 size = sizeof(alive);
+    OSStatus err = AudioObjectGetPropertyData(device, &aliveAddress, 0, NULL, &size, &alive);
+
+    return (err == noErr && alive == 1);
+}
+
+- (bool)refreshPriorityList {
+    connectedNamesByUID = [self connectedOutputDeviceNamesByUID];
+    priorityUIDs = [[self readPriorityUIDsFromDriver] mutableCopy];
+    activeUID = [self currentActiveOutputDeviceUID];
+
+    [self reloadTableIfChanged];
+    [self updatePriorityButtonStates];
+
+    // We have succeeded in talking to the driver as long as we got this far.
+    return true;
+}
+
+// A compact fingerprint of everything the table actually displays: chain order,
+// each row's availability, and which row is active.
+- (NSString *)currentDisplaySignature {
+    NSMutableString *signature = [NSMutableString string];
+
+    for (NSString *uid in priorityUIDs) {
+        BOOL available = [self isUIDAvailable:uid];
+        BOOL active = (activeUID.length > 0 && [activeUID isEqualToString:uid]);
+        [signature appendFormat:@"%@|%d|%d;", uid, available ? 1 : 0, active ? 1 : 0];
+    }
+
+    return signature;
+}
+
+// Reloads the table only when its displayed contents have actually changed. This
+// keeps the 1.5s poll from calling reloadData while nothing has changed, which
+// would otherwise steal the table's focus/selection and make reordering with the
+// up/down buttons fight the refresh. Selection is preserved across real reloads.
+- (void)reloadTableIfChanged {
+    NSString *signature = [self currentDisplaySignature];
+
+    if ([signature isEqualToString:lastDisplaySignature]) {
+        return;
+    }
+
+    lastDisplaySignature = signature;
+
+    NSIndexSet *selectedRows = [self.priorityTableView selectedRowIndexes];
+    [self.priorityTableView reloadData];
+
+    if (selectedRows.count > 0 && selectedRows.lastIndex < priorityUIDs.count) {
+        [self.priorityTableView selectRowIndexes:selectedRows byExtendingSelection:NO];
+    }
+}
+
+- (void)updatePriorityButtonStates {
+    NSInteger selectedRow = self.priorityTableView.selectedRow;
+    BOOL hasSelection = (selectedRow >= 0 && selectedRow < (NSInteger)priorityUIDs.count);
+
+    self.removeDeviceButton.enabled = hasSelection;
+    self.moveUpButton.enabled = hasSelection && selectedRow > 0;
+    self.moveDownButton.enabled = hasSelection && selectedRow < (NSInteger)priorityUIDs.count - 1;
+
+    // The add button is enabled when there is at least one connected device that
+    // is not already in the chain.
+    self.addDeviceButton.enabled = ([self connectedDevicesNotInChain].count > 0);
+}
+
+// After we change the chain, the driver re-evaluates the active device
+// asynchronously (and a reorder fires no system device-change event), so the
+// "Active" marker can briefly lag. Re-read it shortly after to catch up.
+- (void)scheduleActiveMarkerRefresh {
+    __weak WindowDelegate *weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        WindowDelegate *strongSelf = weakSelf;
+
+        if (!strongSelf) {
+            return;
+        }
+
+        strongSelf->activeUID = [strongSelf currentActiveOutputDeviceUID];
+        [strongSelf reloadTableIfChanged];
+    });
+}
+
+- (NSArray<NSString *> *)connectedDevicesNotInChain {
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+
+    for (NSString *uid in connectedNamesByUID) {
+        if (![priorityUIDs containsObject:uid]) {
+            [result addObject:uid];
+        }
+    }
+
+    return result;
+}
+
+#pragma mark - NSTableViewDataSource / NSTableViewDelegate
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+#pragma unused(tableView)
+    return (NSInteger)priorityUIDs.count;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView
+    viewForTableColumn:(NSTableColumn *)tableColumn
+                   row:(NSInteger)row {
+    if (row < 0 || row >= (NSInteger)priorityUIDs.count) {
+        return nil;
+    }
+
+    NSString *uid = priorityUIDs[(NSUInteger)row];
+    NSString *identifier = tableColumn.identifier;
+    NSTextField *cell = [tableView makeViewWithIdentifier:identifier owner:self];
+
+    if (!cell) {
+        cell = [NSTextField labelWithString:@""];
+        cell.identifier = identifier;
+        cell.lineBreakMode = NSLineBreakByTruncatingTail;
+    }
+
+    if ([identifier isEqualToString:kDeviceColumnID]) {
+        cell.stringValue = [self displayNameForUID:uid];
+        cell.toolTip = uid;
+    } else {
+        BOOL available = [self isUIDAvailable:uid];
+        BOOL isActive = (activeUID.length > 0 && [activeUID isEqualToString:uid]);
+
+        if (isActive) {
+            cell.stringValue = NSLocalizedString(@"● Active", nil);
+            cell.textColor = [NSColor systemGreenColor];
+        } else if (available) {
+            cell.stringValue = NSLocalizedString(@"Available", nil);
+            cell.textColor = [NSColor secondaryLabelColor];
+        } else {
+            cell.stringValue = NSLocalizedString(@"Unavailable", nil);
+            cell.textColor = [NSColor tertiaryLabelColor];
+        }
+    }
+
+    return cell;
+}
+
+- (void)tableViewSelectionDidChange:(NSNotification *)notification {
+#pragma unused(notification)
+    [self updatePriorityButtonStates];
+}
+
+#pragma mark - Priority list actions
+
+- (void)addDeviceClicked:(id)sender {
+#pragma unused(sender)
+    NSArray<NSString *> *candidates = [self connectedDevicesNotInChain];
+
+    if (candidates.count == 0) {
+        return;
+    }
+
+    // Sort candidates by display name for a predictable menu order.
+    NSArray<NSString *> *sorted = [candidates sortedArrayUsingComparator:^NSComparisonResult(NSString *a, NSString *b) {
+        return [[self displayNameForUID:a] caseInsensitiveCompare:[self displayNameForUID:b]];
+    }];
+
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+
+    for (NSString *uid in sorted) {
+        NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:[self displayNameForUID:uid]
+                                                      action:@selector(addSpecificDevice:)
+                                               keyEquivalent:@""];
+        item.target = self;
+        item.representedObject = uid;
+        [menu addItem:item];
+    }
+
+    [menu popUpMenuPositioningItem:nil
+                        atLocation:NSMakePoint(0, self.addDeviceButton.bounds.size.height)
+                            inView:self.addDeviceButton];
+}
+
+- (void)addSpecificDevice:(NSMenuItem *)sender {
+    NSString *uid = sender.representedObject;
+
+    if (uid.length == 0 || [priorityUIDs containsObject:uid]) {
+        return;
+    }
+
+    [priorityUIDs addObject:uid];
+    [self writePriorityUIDsToDriver];
+    [self refreshPriorityList];
+    [self scheduleActiveMarkerRefresh];
+
+    NSInteger newRow = (NSInteger)priorityUIDs.count - 1;
+    [self.priorityTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
+}
+
+- (void)removeDeviceClicked:(id)sender {
+#pragma unused(sender)
+    NSInteger row = self.priorityTableView.selectedRow;
+
+    if (row < 0 || row >= (NSInteger)priorityUIDs.count) {
+        return;
+    }
+
+    [priorityUIDs removeObjectAtIndex:(NSUInteger)row];
+    [self writePriorityUIDsToDriver];
+    [self refreshPriorityList];
+    [self scheduleActiveMarkerRefresh];
+}
+
+- (void)moveDeviceUpClicked:(id)sender {
+#pragma unused(sender)
+    [self moveSelectedRowByOffset:-1];
+}
+
+- (void)moveDeviceDownClicked:(id)sender {
+#pragma unused(sender)
+    [self moveSelectedRowByOffset:1];
+}
+
+- (void)moveSelectedRowByOffset:(NSInteger)offset {
+    NSInteger row = self.priorityTableView.selectedRow;
+    NSInteger target = row + offset;
+
+    if (row < 0 || row >= (NSInteger)priorityUIDs.count || target < 0 || target >= (NSInteger)priorityUIDs.count) {
+        return;
+    }
+
+    NSString *uid = priorityUIDs[(NSUInteger)row];
+    [priorityUIDs removeObjectAtIndex:(NSUInteger)row];
+    [priorityUIDs insertObject:uid atIndex:(NSUInteger)target];
+    [self writePriorityUIDsToDriver];
+    [self refreshPriorityList];
+    [self.priorityTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:target] byExtendingSelection:NO];
+    [self scheduleActiveMarkerRefresh];
+}
+
+- (void)autoFailbackToggled:(id)sender {
+#pragma unused(sender)
+    BOOL on = (self.autoFailbackCheckbox.state == NSControlStateValueOn);
+    [self writeConfigString:[NSString stringWithFormat:@"outputDeviceAutoFailback=%d", on ? 1 : 0]];
+    [self scheduleActiveMarkerRefresh];
+}
+
+// Retained for the existing XIB action connection on the now-hidden combo box.
 - (IBAction)outputDeviceSelected:(id)sender {
 #pragma unused(sender)
-    unsigned long index = (unsigned long)self.outputDeviceComboBox.indexOfSelectedItem;
-    
-    if (index < 0 || index >= currentDeviceList.size()) {
-        NSLog(@"Error: got invalid selection index when trying to set output device");
-        return;
-    }
-
-    NSString *uid = (__bridge_transfer NSString *)AudioDevice::copyDeviceUID(currentDeviceList[index]);
-    
-    if (!uid) {
-        NSLog(@"Error: got invalid UID when trying to set output device");
-        return;
-    }
-
-    AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
-    AudioDevice::setObjectName(proxyAudioBox,
-                               (__bridge_retained CFStringRef)[NSString stringWithFormat:@"outputDevice=%@", uid]);
 }
+
+#pragma mark - Buffer size
 
 - (NSString *)currentOutputDeviceBufferFrameSize {
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setIdentifyValue(proxyAudioBox, -((SInt32)ProxyAudioDevice::ConfigType::outputDeviceBufferFrameSize));
     NSString *result = (__bridge_transfer NSString *)AudioDevice::copyObjectName(proxyAudioBox);
-    
+
     return result ? result : @"";
 }
 
@@ -244,9 +614,10 @@ int onDevicesChanged(AudioObjectID inObjectID,
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setObjectName(
         proxyAudioBox,
-        (__bridge_retained CFStringRef)
-            [NSString stringWithFormat:@"outputDeviceBufferFrameSize=%@", newBufferFrameSizeString]);
+        (__bridge CFStringRef)[NSString stringWithFormat:@"outputDeviceBufferFrameSize=%@", newBufferFrameSizeString]);
 }
+
+#pragma mark - Active condition
 
 - (ProxyAudioDevice::ActiveCondition)currentOutputDeviceActiveCondition {
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
@@ -260,30 +631,31 @@ int onDevicesChanged(AudioObjectID inObjectID,
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setObjectName(
         proxyAudioBox,
-        (__bridge_retained CFStringRef)
-            [NSString stringWithFormat:@"outputDeviceActiveCondition=%d", condition]);
+        (__bridge CFStringRef)[NSString stringWithFormat:@"outputDeviceActiveCondition=%d", condition]);
 }
 
 - (IBAction)proxiedDeviceIsActiveConditionSelected:(id)sender {
-    #pragma unused(sender)
+#pragma unused(sender)
     self.alwaysRadioButton.state = NSControlStateValueOff;
     self.userIsActiveRadioButton.state = NSControlStateValueOff;
     [self setCurrentOutputDeviceActiveCondition:ProxyAudioDevice::ActiveCondition::proxiedDeviceActive];
 }
 
 - (IBAction)userIsActiveConditionSelected:(id)sender {
-    #pragma unused(sender)
+#pragma unused(sender)
     self.alwaysRadioButton.state = NSControlStateValueOff;
     self.proxiedDeviceIsActiveRadioButton.state = NSControlStateValueOff;
     [self setCurrentOutputDeviceActiveCondition:ProxyAudioDevice::ActiveCondition::userActive];
 }
 
 - (IBAction)alwaysConditionSelected:(id)sender {
-    #pragma unused(sender)
+#pragma unused(sender)
     self.proxiedDeviceIsActiveRadioButton.state = NSControlStateValueOff;
     self.userIsActiveRadioButton.state = NSControlStateValueOff;
     [self setCurrentOutputDeviceActiveCondition:ProxyAudioDevice::ActiveCondition::always];
 }
+
+#pragma mark - Hide when unavailable
 
 // The driver reports this preference as "1" or "0" (see copyConfigurationValue
 // in ProxyAudioDevice.cpp). Anything non-"1" is treated as false.
@@ -299,13 +671,180 @@ int onDevicesChanged(AudioObjectID inObjectID,
     AudioDeviceID proxyAudioBox = AudioDevice::audioDeviceIDForBoxUID(CFSTR(kBox_UID));
     AudioDevice::setObjectName(
         proxyAudioBox,
-        (__bridge_retained CFStringRef)
-            [NSString stringWithFormat:@"outputDeviceHideWhenUnavailable=%d", hide ? 1 : 0]);
+        (__bridge CFStringRef)[NSString stringWithFormat:@"outputDeviceHideWhenUnavailable=%d", hide ? 1 : 0]);
 }
 
 - (IBAction)hideWhenUnavailableToggled:(id)sender {
-    #pragma unused(sender)
+#pragma unused(sender)
     [self setCurrentHideWhenUnavailable:(self.hideWhenUnavailableCheckbox.state == NSControlStateValueOn)];
+}
+
+#pragma mark - Programmatic priority list UI
+
+// Finds a subview of `parent` whose frame origin matches (x, y). Used to locate
+// the static "Proxy device name:" and "Proxied device:" labels, which have no
+// outlets, by their known XIB frame origins -- locale-independent.
+static NSView *findSubviewByOrigin(NSView *parent, CGFloat x, CGFloat y) {
+    for (NSView *view in parent.subviews) {
+        if (fabs(view.frame.origin.x - x) < 1.0 && fabs(view.frame.origin.y - y) < 1.0) {
+            return view;
+        }
+    }
+
+    return nil;
+}
+
+- (void)setupPriorityListUI {
+    if (priorityUIBuilt) {
+        return;
+    }
+
+    NSWindow *window = self.deviceNameTextField.window;
+    NSView *contentView = window.contentView;
+
+    if (!window || !contentView) {
+        return;
+    }
+
+    const CGFloat E = kPriorityUIExtraHeight;
+
+    // Grow the window upward without disturbing the existing fixed-frame controls:
+    // disable subview autoresizing for the height change, then reposition only the
+    // controls we care about explicitly. Horizontal resizing is restored after.
+    contentView.autoresizesSubviews = NO;
+
+    NSRect frame = window.frame;
+    frame.size.height += E;
+    [window setFrame:frame display:YES];
+
+    NSSize maxSize = window.contentMaxSize;
+    NSSize minSize = window.contentMinSize;
+    maxSize.height += E;
+    minSize.height += E;
+    window.contentMaxSize = maxSize;
+    window.contentMinSize = minSize;
+
+    contentView.autoresizesSubviews = YES;
+
+    // Hide the legacy single-device combo box; it is replaced by the table.
+    self.outputDeviceComboBox.hidden = YES;
+
+    // Shift the top rows (name label/field and the "Proxied device:" label) up by
+    // E so the opened band sits between them and the unchanged buffer-size row.
+    NSView *nameLabel = findSubviewByOrigin(contentView, 10.0, 295.0);
+    NSView *proxiedLabel = findSubviewByOrigin(contentView, 10.0, 263.0);
+
+    if (nameLabel) {
+        NSRect r = nameLabel.frame;
+        r.origin.y += E;
+        nameLabel.frame = r;
+    }
+
+    {
+        NSRect r = self.deviceNameTextField.frame;
+        r.origin.y += E;
+        self.deviceNameTextField.frame = r;
+    }
+
+    if ([proxiedLabel isKindOfClass:[NSTextField class]]) {
+        NSRect r = proxiedLabel.frame;
+        r.origin.y += E;
+        r.size.width = 142.0;
+        proxiedLabel.frame = r;
+        [(NSTextField *)proxiedLabel setStringValue:NSLocalizedString(@"Priority devices:", nil)];
+    }
+
+    // Lay out the table, the +/-/up/down buttons, and the auto-failback checkbox
+    // in the opened band (between y=251 buffer row and y=413 proxied label).
+    NSRect tableFrame = NSMakeRect(kPriorityListLeftX, 311.0, kPriorityListWidth, 96.0);
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:tableFrame];
+    scrollView.hasVerticalScroller = YES;
+    scrollView.borderType = NSBezelBorder;
+    scrollView.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+
+    NSTableView *tableView = [[NSTableView alloc] initWithFrame:scrollView.bounds];
+    tableView.usesAlternatingRowBackgroundColors = YES;
+    tableView.allowsMultipleSelection = NO;
+    tableView.rowSizeStyle = NSTableViewRowSizeStyleDefault;
+    tableView.dataSource = self;
+    tableView.delegate = self;
+
+    NSTableColumn *deviceColumn = [[NSTableColumn alloc] initWithIdentifier:kDeviceColumnID];
+    deviceColumn.title = NSLocalizedString(@"Device", nil);
+    deviceColumn.width = 224.0;
+    deviceColumn.minWidth = 120.0;
+    [tableView addTableColumn:deviceColumn];
+
+    NSTableColumn *statusColumn = [[NSTableColumn alloc] initWithIdentifier:kStatusColumnID];
+    statusColumn.title = NSLocalizedString(@"Status", nil);
+    statusColumn.width = 96.0;
+    statusColumn.minWidth = 80.0;
+    [tableView addTableColumn:statusColumn];
+
+    scrollView.documentView = tableView;
+    [contentView addSubview:scrollView];
+    self.priorityTableView = tableView;
+
+    // Buttons row beneath the table.
+    const CGFloat buttonY = 285.0;
+    const CGFloat buttonW = 30.0;
+    const CGFloat buttonH = 22.0;
+    self.addDeviceButton = [self makeToolButtonWithTitle:@"+"
+                                                       x:kPriorityListLeftX
+                                                       y:buttonY
+                                                   width:buttonW
+                                                  height:buttonH
+                                                  action:@selector(addDeviceClicked:)
+                                                 toolTip:NSLocalizedString(@"Add a device to the priority list", nil)];
+    self.removeDeviceButton = [self makeToolButtonWithTitle:@"−"
+                                                          x:kPriorityListLeftX + buttonW
+                                                          y:buttonY
+                                                      width:buttonW
+                                                     height:buttonH
+                                                     action:@selector(removeDeviceClicked:)
+                                                    toolTip:NSLocalizedString(@"Remove the selected device", nil)];
+    self.moveUpButton = [self makeToolButtonWithTitle:@"▲"
+                                                    x:kPriorityListLeftX + buttonW * 2 + 8.0
+                                                    y:buttonY
+                                                width:buttonW
+                                               height:buttonH
+                                               action:@selector(moveDeviceUpClicked:)
+                                              toolTip:NSLocalizedString(@"Move the selected device up", nil)];
+    self.moveDownButton = [self makeToolButtonWithTitle:@"▼"
+                                                      x:kPriorityListLeftX + buttonW * 3 + 8.0
+                                                      y:buttonY
+                                                  width:buttonW
+                                                 height:buttonH
+                                                 action:@selector(moveDeviceDownClicked:)
+                                                toolTip:NSLocalizedString(@"Move the selected device down", nil)];
+
+    // Auto-failback checkbox beneath the buttons.
+    NSButton *checkbox = [NSButton checkboxWithTitle:NSLocalizedString(@"Automatically switch back to higher-priority devices", nil)
+                                              target:self
+                                              action:@selector(autoFailbackToggled:)];
+    checkbox.frame = NSMakeRect(kPriorityListLeftX, 257.0, kPriorityListWidth, 18.0);
+    checkbox.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+    [contentView addSubview:checkbox];
+    self.autoFailbackCheckbox = checkbox;
+
+    priorityUIBuilt = true;
+}
+
+- (NSButton *)makeToolButtonWithTitle:(NSString *)title
+                                    x:(CGFloat)x
+                                    y:(CGFloat)y
+                                width:(CGFloat)width
+                               height:(CGFloat)height
+                               action:(SEL)action
+                              toolTip:(NSString *)toolTip {
+    NSButton *button = [NSButton buttonWithTitle:title target:self action:action];
+    button.frame = NSMakeRect(x, y, width, height);
+    button.bezelStyle = NSBezelStyleRounded;
+    button.autoresizingMask = NSViewMaxXMargin | NSViewMinYMargin;
+    button.toolTip = toolTip;
+    NSView *contentView = self.deviceNameTextField.window.contentView;
+    [contentView addSubview:button];
+    return button;
 }
 
 @end

--- a/ProxyAudioDeviceSettings/WindowDelegate.mm
+++ b/ProxyAudioDeviceSettings/WindowDelegate.mm
@@ -460,7 +460,13 @@ int onDevicesChanged(AudioObjectID inObjectID,
     NSTextField *cell = [tableView makeViewWithIdentifier:identifier owner:self];
 
     if (!cell) {
-        cell = [NSTextField labelWithString:@""];
+        // Configure a non-editable label by hand: +[NSTextField labelWithString:]
+        // is 10.12+, and we support macOS 10.11.
+        cell = [[NSTextField alloc] initWithFrame:NSZeroRect];
+        cell.editable = NO;
+        cell.selectable = NO;
+        cell.bezeled = NO;
+        cell.drawsBackground = NO;
         cell.identifier = identifier;
         cell.lineBreakMode = NSLineBreakByTruncatingTail;
     }
@@ -818,10 +824,13 @@ static NSView *findSubviewByOrigin(NSView *parent, CGFloat x, CGFloat y) {
                                                  action:@selector(moveDeviceDownClicked:)
                                                 toolTip:NSLocalizedString(@"Move the selected device down", nil)];
 
-    // Auto-failback checkbox beneath the buttons.
-    NSButton *checkbox = [NSButton checkboxWithTitle:NSLocalizedString(@"Automatically switch back to higher-priority devices", nil)
-                                              target:self
-                                              action:@selector(autoFailbackToggled:)];
+    // Auto-failback checkbox beneath the buttons. +[NSButton checkboxWithTitle:...]
+    // is 10.12+, so configure a switch button by hand for macOS 10.11 support.
+    NSButton *checkbox = [[NSButton alloc] initWithFrame:NSZeroRect];
+    [checkbox setButtonType:NSButtonTypeSwitch];
+    checkbox.title = NSLocalizedString(@"Automatically switch back to higher-priority devices", nil);
+    checkbox.target = self;
+    checkbox.action = @selector(autoFailbackToggled:);
     checkbox.frame = NSMakeRect(kPriorityListLeftX, 257.0, kPriorityListWidth, 18.0);
     checkbox.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
     [contentView addSubview:checkbox];
@@ -837,7 +846,13 @@ static NSView *findSubviewByOrigin(NSView *parent, CGFloat x, CGFloat y) {
                                height:(CGFloat)height
                                action:(SEL)action
                               toolTip:(NSString *)toolTip {
-    NSButton *button = [NSButton buttonWithTitle:title target:self action:action];
+    // +[NSButton buttonWithTitle:...] is 10.12+; build a push button by hand to
+    // keep macOS 10.11 compatibility.
+    NSButton *button = [[NSButton alloc] initWithFrame:NSZeroRect];
+    [button setButtonType:NSButtonTypeMomentaryPushIn];
+    button.title = title;
+    button.target = self;
+    button.action = action;
     button.frame = NSMakeRect(x, y, width, height);
     button.bezelStyle = NSBezelStyleRounded;
     button.autoresizingMask = NSViewMaxXMargin | NSViewMinYMargin;

--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -567,10 +567,11 @@ OSStatus ProxyAudioDevice::Initialize(AudioServerPlugInDriverRef inDriver, Audio
     dispatch_resume(inputMonitoringTimer);
     
     deviceName = copyDeviceNameFromStorage();
-    outputDeviceUID = copyOutputDeviceUIDFromStorage();
+    outputDevicePriorityList = copyOutputDevicePriorityListFromStorage();
     outputDeviceBufferFrameSize = retrieveOutputDeviceBufferFrameSizeFromStorage();
     outputDeviceActiveCondition = retrieveOutputDeviceActiveConditionFromStorage();
     outputDeviceHideWhenUnavailable = retrieveOutputDeviceHideWhenUnavailableFromStorage();
+    outputDeviceAutoFailback = retrieveOutputDeviceAutoFailbackFromStorage();
 
     //    calculate the host ticks per frame
     struct mach_timebase_info theTimeBaseInfo;
@@ -4661,43 +4662,109 @@ Done:
 
 #pragma mark Output Device Operations
 
-AudioDevice ProxyAudioDevice::findTargetOutputAudioDevice() {
-    DebugMsg("ProxyAudio: findTargetOutputAudioDevice");
-    std::vector<AudioObjectID> devices = AudioDevice::allAudioDevices();
-    CFStringSmartRef currentOutputDeviceUID;
-    
+// Returns true if the given device UID currently maps to a device that is both
+// present in the system and reporting itself as alive. "Available" = present AND
+// alive, matching the two failure signals the driver already listens for
+// (devicesListenerProc for removal, outputDeviceAliveListener for death).
+static bool deviceUIDIsAvailable(CFStringRef uid, AudioObjectID &outDeviceID) {
+    outDeviceID = kAudioObjectUnknown;
+
+    if (!uid || CFStringGetLength(uid) == 0) {
+        return false;
+    }
+
+    AudioObjectID deviceID = AudioDevice::audioDeviceIDForDeviceUID(uid);
+
+    if (deviceID == kAudioObjectUnknown) {
+        return false;
+    }
+
+    AudioObjectPropertyAddress aliveAddress = {
+        kAudioDevicePropertyDeviceIsAlive, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster};
+    UInt32 alive = 0;
+    UInt32 size = sizeof(alive);
+    OSStatus err = AudioObjectGetPropertyData(deviceID, &aliveAddress, 0, NULL, &size, &alive);
+
+    if (err != noErr || alive != 1) {
+        return false;
+    }
+
+    outDeviceID = deviceID;
+    return true;
+}
+
+CFStringRef ProxyAudioDevice::copyChosenTargetDeviceUID(CFStringRef currentActiveUID) {
+    // Snapshot the chain + auto-failback setting so we don't hold stateMutex
+    // across the CoreAudio availability queries below.
+    CFArraySmartRef priorityList;
+    bool autoFailback;
     {
         CAMutex::Locker locker(&stateMutex);
-        
-        if (!outputDeviceUID) {
-            DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, output device UID is null");
-            return AudioDevice();
-        }
-        
-        currentOutputDeviceUID = CFStringCreateCopy(NULL, outputDeviceUID);
+        priorityList = outputDevicePriorityList ? (CFArrayRef)CFRetain(outputDevicePriorityList) : NULL;
+        autoFailback = outputDeviceAutoFailback;
     }
-    
-    DebugMsg("ProxyAudio: findTargetOutputAudioDevice target UID: %s", CFStringToStdString(currentOutputDeviceUID).c_str());
-    
-    for (AudioObjectID device : devices) {
-        AudioObjectPropertyAddress propertyAddress = {
-            kAudioDevicePropertyDeviceUID, kAudioObjectPropertyScopeOutput, kAudioObjectPropertyElementMaster};
 
-        CFStringSmartRef uid;
-        UInt32 size = sizeof(CFStringRef);
-        OSStatus err = AudioObjectGetPropertyData(device, &propertyAddress, 0, NULL, &size, &uid);
+    // Walk the chain in priority order and collect the entries that are currently
+    // available. The CFStringRefs are borrowed from priorityList, which stays
+    // retained for the lifetime of this function.
+    std::vector<CFStringRef> availableListed;
+    CFIndex count = priorityList ? CFArrayGetCount(priorityList) : 0;
 
-        if (err == noErr && uid) {
-            if (CFStringCompare(uid, currentOutputDeviceUID, 0) == kCFCompareEqualTo) {
-                DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, found output device");
-                return AudioDevice(device);
+    for (CFIndex i = 0; i < count; ++i) {
+        CFStringRef uid = (CFStringRef)CFArrayGetValueAtIndex(priorityList, i);
+        AudioObjectID deviceID = kAudioObjectUnknown;
+
+        if (deviceUIDIsAvailable(uid, deviceID)) {
+            availableListed.push_back(uid);
+        }
+    }
+
+    if (!availableListed.empty()) {
+        if (!autoFailback && currentActiveUID && CFStringGetLength(currentActiveUID) > 0) {
+            // Sticky (auto-failback off): keep the current device if it is still
+            // among the available listed devices; otherwise advance to the
+            // highest-priority available one.
+            for (CFStringRef uid : availableListed) {
+                if (CFStringCompare(uid, currentActiveUID, 0) == kCFCompareEqualTo) {
+                    return CFStringCreateCopy(NULL, uid);
+                }
             }
         }
+
+        // Auto-failback on, or the current device is no longer available: use the
+        // highest-priority available listed device.
+        return CFStringCreateCopy(NULL, availableListed.front());
     }
 
-    DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, not not find output device");
-    
-    return AudioDevice();
+    // No listed device is available: fall back to the current system default
+    // output device (which already excludes the proxy device itself). The
+    // fallback is never sticky -- as soon as any listed device returns, the logic
+    // above selects it on the next re-evaluation, regardless of the auto-failback
+    // setting (the fallback is never in availableListed).
+    return copyDefaultProxyOutputDeviceUID();
+}
+
+AudioDevice ProxyAudioDevice::findTargetOutputAudioDevice(CFStringRef currentActiveUID) {
+    DebugMsg("ProxyAudio: findTargetOutputAudioDevice");
+
+    CFStringSmartRef targetUID = copyChosenTargetDeviceUID(currentActiveUID);
+
+    if (!targetUID || CFStringGetLength(targetUID) == 0) {
+        DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, no available device");
+        return AudioDevice();
+    }
+
+    DebugMsg("ProxyAudio: findTargetOutputAudioDevice target UID: %s", CFStringToStdString(targetUID).c_str());
+
+    AudioObjectID deviceID = AudioDevice::audioDeviceIDForDeviceUID(targetUID);
+
+    if (deviceID == kAudioObjectUnknown) {
+        DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, could not resolve device");
+        return AudioDevice();
+    }
+
+    DebugMsg("ProxyAudio: findTargetOutputAudioDevice finished, found output device");
+    return AudioDevice(deviceID);
 }
 
 int ProxyAudioDevice::outputDeviceAliveListenerStatic(AudioObjectID inObjectID,
@@ -4732,6 +4799,13 @@ int ProxyAudioDevice::outputDeviceAliveListener(AudioObjectID inObjectID,
 
     DebugMsg("ProxyAudio: outputDeviceAliveListener output device no longer alive");
     deinitializeOutputDevice();
+
+    // The active device died but other devices in the chain (or the system-default
+    // fallback) may still be available, so immediately re-evaluate and advance
+    // rather than waiting for a separate device-list change event. A dying device
+    // does not always disappear from the device list, so we cannot rely on
+    // devicesListenerProc to fire.
+    setupTargetOutputDevice();
 
     return noErr;
 }
@@ -4889,44 +4963,65 @@ void ProxyAudioDevice::matchOutputDeviceSampleRate()
 
 void ProxyAudioDevice::setupTargetOutputDevice() {
     DebugMsg("ProxyAudio: setupTargetOutputDevice");
-    AudioDevice newOutputDevice = findTargetOutputAudioDevice();
 
+    // Capture the UID of the device currently in use so the selection logic can
+    // honor sticky behavior (auto-failback off): we only stay put if the current
+    // device is still among the available listed devices.
+    CFStringSmartRef currentActiveUID;
+    {
+        CAMutex::Locker locker(outputDeviceMutex);
+        if (outputDevice.isValid()) {
+            currentActiveUID = AudioDevice::copyDeviceUID(outputDevice.id);
+        }
+    }
+
+    AudioDevice newOutputDevice = findTargetOutputAudioDevice(currentActiveUID);
     DebugMsg("ProxyAudio: setupTargetOutputDevice newOutputDevice: %d", newOutputDevice.id);
-    CAMutex::Locker locker(outputDeviceMutex);
-    
-    if (outputDevice.isValid() && outputDevice.id == newOutputDevice.id
-        && outputDevice.bufferFrameSize == outputDeviceBufferFrameSize) {
-        DebugMsg("ProxyAudio: setupTargetOutputDevice no change in device");
-        return;
+
+    AudioObjectID activeDeviceID = kAudioObjectUnknown;
+    {
+        CAMutex::Locker locker(outputDeviceMutex);
+
+        if (outputDevice.isValid() && outputDevice.id == newOutputDevice.id
+            && outputDevice.bufferFrameSize == outputDeviceBufferFrameSize) {
+            DebugMsg("ProxyAudio: setupTargetOutputDevice no change in device");
+            activeDeviceID = outputDevice.id;
+        } else {
+            DebugMsg("ProxyAudio: setupTargetOutputDevice deinitializing old device");
+            // NB: it's important that we not modify OutputDevice until it is no longer playing since
+            // we're not using a locking mechanism on its attributes between this function and its IO
+            // function.
+            deinitializeOutputDeviceNoLock();
+
+            if (newOutputDevice.isValid()) {
+                DebugMsg("ProxyAudio: setupTargetOutputDevice setting up new device");
+                resetInputData();
+                outputDevice = newOutputDevice;
+                outputDevice.setBufferFrameSize(outputDeviceBufferFrameSize);
+                outputDevice.setupIOProc(outputDeviceIOProcStatic, this);
+                outputDevice.addPropertyListener(kAudioDevicePropertyDeviceIsAlive,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMaster,
+                                                 outputDeviceAliveListenerStatic,
+                                                 this);
+                outputDevice.addPropertyListener(kAudioDevicePropertyNominalSampleRate,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMaster,
+                                                 outputDeviceSampleRateListenerStatic,
+                                                 this);
+                DebugMsg("ProxyAudio: setupTargetOutputDevice will match sample rate");
+                matchOutputDeviceSampleRateNoLock();
+                activeDeviceID = outputDevice.id;
+            } else {
+                syslog(LOG_WARNING, "ProxyAudio: setupTargetOutputDevice could not find output device");
+            }
+        }
     }
 
-    DebugMsg("ProxyAudio: setupTargetOutputDevice deinitializing old device");
-    // NB: it's important that we not modify OutputDevice until it is no longer playing since
-    // we're not using a locking mechanism on its attributes between this function and its IO
-    // function.
-    deinitializeOutputDeviceNoLock();
-
-    if (newOutputDevice.isValid()) {
-        DebugMsg("ProxyAudio: setupTargetOutputDevice setting up new device");
-        resetInputData();
-        outputDevice = newOutputDevice;
-        outputDevice.setBufferFrameSize(outputDeviceBufferFrameSize);
-        outputDevice.setupIOProc(outputDeviceIOProcStatic, this);
-        outputDevice.addPropertyListener(kAudioDevicePropertyDeviceIsAlive,
-                                         kAudioObjectPropertyScopeGlobal,
-                                         kAudioObjectPropertyElementMaster,
-                                         outputDeviceAliveListenerStatic,
-                                         this);
-        outputDevice.addPropertyListener(kAudioDevicePropertyNominalSampleRate,
-                                         kAudioObjectPropertyScopeGlobal,
-                                         kAudioObjectPropertyElementMaster,
-                                         outputDeviceSampleRateListenerStatic,
-                                         this);
-        DebugMsg("ProxyAudio: setupTargetOutputDevice will match sample rate");
-        matchOutputDeviceSampleRateNoLock();
-    } else {
-        syslog(LOG_WARNING, "ProxyAudio: setupTargetOutputDevice could not find output device");
-    }
+    // Record which device we actually ended up routing to (a chain entry, the
+    // system-default fallback, or none) so the settings app can mark the active
+    // row, read via ConfigType::currentActiveOutputDevice.
+    updateCurrentActiveOutputDeviceUID(activeDeviceID);
 }
 
 void ProxyAudioDevice::initializeOutputDevice() {
@@ -4937,10 +5032,9 @@ void ProxyAudioDevice::initializeOutputDevice() {
                        // in a separate thread from the rest of the driver. Otherwise we'll get
                        // deadlocks!
                        DebugMsg("ProxyAudio: initializeOutputDevice running in separate thread");
-                       if (!outputDeviceUID) {
-                           outputDeviceUID = copyDefaultProxyOutputDeviceUID();
-                       }
-                       
+                       // Device selection is driven entirely by the priority chain
+                       // (and the system-default fallback when no listed device is
+                       // available), resolved in setupTargetOutputDevice.
                        setupTargetOutputDevice();
                        setupAudioDevicesListener();
                    });
@@ -5507,8 +5601,8 @@ void ProxyAudioDevice::parseConfigurationString(CFStringRef configString, Config
 
     CFStringSmartRef actionString = CFStringCreateWithSubstring(NULL, configString, CFRangeMake(0, splitter.location));
 
-    if (CFStringCompare(actionString, CFSTR("outputDevice"), 0) == kCFCompareEqualTo) {
-        action = ConfigType::outputDevice;
+    if (CFStringCompare(actionString, CFSTR("outputDevicePriorityList"), 0) == kCFCompareEqualTo) {
+        action = ConfigType::outputDevicePriorityList;
     } else if (CFStringCompare(actionString, CFSTR("outputDeviceBufferFrameSize"), 0) == kCFCompareEqualTo) {
         action = ConfigType::outputDeviceBufferFrameSize;
     } else if (CFStringCompare(actionString, CFSTR("deviceName"), 0) == kCFCompareEqualTo) {
@@ -5517,6 +5611,8 @@ void ProxyAudioDevice::parseConfigurationString(CFStringRef configString, Config
         action = ConfigType::deviceActiveCondition;
     } else if (CFStringCompare(actionString, CFSTR("outputDeviceHideWhenUnavailable"), 0) == kCFCompareEqualTo) {
         action = ConfigType::deviceHideWhenUnavailable;
+    } else if (CFStringCompare(actionString, CFSTR("outputDeviceAutoFailback"), 0) == kCFCompareEqualTo) {
+        action = ConfigType::outputDeviceAutoFailback;
     } else {
         return;
     }
@@ -5536,8 +5632,8 @@ void ProxyAudioDevice::parseConfigurationString(CFStringRef configString, Config
 
 void ProxyAudioDevice::setConfigurationValue(ConfigType type, CFStringRef value) {
     switch (type) {
-        case ConfigType::outputDevice:
-            setOutputDevice(value);
+        case ConfigType::outputDevicePriorityList:
+            setOutputDevicePriorityList(value);
             break;
 
         case ConfigType::outputDeviceBufferFrameSize:
@@ -5557,6 +5653,11 @@ void ProxyAudioDevice::setConfigurationValue(ConfigType type, CFStringRef value)
             setOutputDeviceHideWhenUnavailable(CFStringGetIntValue(value) != 0);
             break;
 
+        case ConfigType::outputDeviceAutoFailback:
+            // Configurator passes "1" for true and "0" for false.
+            setOutputDeviceAutoFailback(CFStringGetIntValue(value) != 0);
+            break;
+
         default:
             break;
     }
@@ -5564,14 +5665,14 @@ void ProxyAudioDevice::setConfigurationValue(ConfigType type, CFStringRef value)
 
 CFStringRef ProxyAudioDevice::copyConfigurationValue(ConfigType type) {
     CAMutex::Locker locker(stateMutex);
-    
+
     switch (type) {
-        case ConfigType::outputDevice:
-            return CFStringCreateCopy(NULL, outputDeviceUID);
-            
+        case ConfigType::outputDevicePriorityList:
+            return copyOutputDevicePriorityListAsString();
+
         case ConfigType::outputDeviceBufferFrameSize:
             return CFStringCreateWithFormat(NULL, NULL, CFSTR("%u"), outputDeviceBufferFrameSize);
-                
+
         case ConfigType::deviceName:
             return CFStringCreateCopy(NULL, deviceName);
 
@@ -5580,6 +5681,14 @@ CFStringRef ProxyAudioDevice::copyConfigurationValue(ConfigType type) {
 
         case ConfigType::deviceHideWhenUnavailable:
             return CFStringCreateWithFormat(NULL, NULL, CFSTR("%u"), outputDeviceHideWhenUnavailable ? 1 : 0);
+
+        case ConfigType::outputDeviceAutoFailback:
+            return CFStringCreateWithFormat(NULL, NULL, CFSTR("%u"), outputDeviceAutoFailback ? 1 : 0);
+
+        case ConfigType::currentActiveOutputDevice:
+            // Empty string (not NULL) when nothing is active, so the read channel
+            // always returns a valid string the settings app can compare against.
+            return outputDeviceUID ? CFStringCreateCopy(NULL, outputDeviceUID) : CFStringCreateCopy(NULL, CFSTR(""));
 
         default:
             return nullptr;
@@ -5674,54 +5783,123 @@ CFStringRef ProxyAudioDevice::copyDefaultProxyOutputDeviceUID() {
     return nullptr;
 }
 
-CFStringRef ProxyAudioDevice::copyOutputDeviceUIDFromStorage() {
-    DebugMsg("ProxyAudio: copyOutputDeviceUIDFromStorage");
-    
+CFArrayRef ProxyAudioDevice::copyOutputDevicePriorityListFromStorage() {
+    DebugMsg("ProxyAudio: copyOutputDevicePriorityListFromStorage");
+
     if (!gPlugIn_Host) {
-        DebugMsg("ProxyAudio: copyOutputDeviceUIDFromStorage no plugin host");
+        DebugMsg("ProxyAudio: copyOutputDevicePriorityListFromStorage no plugin host");
         return nullptr;
     }
 
-    CFStringRef result = nullptr;
     CFPropertyListSmartRef data;
+    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("outputDevicePriorityList"), &data);
 
-    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("outputDeviceUID"), &data);
-
-    if (data != NULL && CFGetTypeID(data) == CFStringGetTypeID()
-        && CFStringCompare(CFStringRef(CFPropertyListRef(data)), CFSTR(kDevice_UID), 0) != kCFCompareEqualTo) {
-        result = CFStringCreateCopy(NULL, CFStringRef(CFPropertyListRef(data)));
-        DebugMsg("ProxyAudio: copyOutputDeviceUIDFromStorage finished with stored output device UID");
-        return result;
+    if (data == NULL || CFGetTypeID(data) != CFArrayGetTypeID()) {
+        DebugMsg("ProxyAudio: copyOutputDevicePriorityListFromStorage no priority list in storage");
+        return nullptr;
     }
 
-    DebugMsg("ProxyAudio: copyOutputDeviceUIDFromStorage no output device UID in storage");
-    
-    return nullptr;
+    // Defensive copy: keep only string entries, and never the proxy device itself
+    // (which would route audio back into the proxy).
+    CFArrayRef stored = (CFArrayRef)CFPropertyListRef(data);
+    CFIndex count = CFArrayGetCount(stored);
+    CFMutableArrayRef result = CFArrayCreateMutable(NULL, count, &kCFTypeArrayCallBacks);
+
+    for (CFIndex i = 0; i < count; ++i) {
+        CFTypeRef entry = CFArrayGetValueAtIndex(stored, i);
+
+        if (!entry || CFGetTypeID(entry) != CFStringGetTypeID()) {
+            continue;
+        }
+
+        if (CFStringCompare((CFStringRef)entry, CFSTR(kDevice_UID), 0) == kCFCompareEqualTo) {
+            continue;
+        }
+
+        CFArrayAppendValue(result, entry);
+    }
+
+    DebugMsg("ProxyAudio: copyOutputDevicePriorityListFromStorage finished with stored priority list");
+
+    return result;
 }
 
-void ProxyAudioDevice::setOutputDevice(CFStringRef deviceUID) {
-    if (!gPlugIn_Host) {
+void ProxyAudioDevice::setOutputDevicePriorityList(CFStringRef newlineDelimitedUIDs) {
+    if (!gPlugIn_Host || !newlineDelimitedUIDs) {
         return;
     }
-    
+
+    // Parse the newline-delimited UID blob into an ordered array, dropping empty
+    // entries and the proxy device itself.
+    CFArraySmartRef rawList =
+        CFStringCreateArrayBySeparatingStrings(NULL, newlineDelimitedUIDs, kOutputDevicePriorityListSeparator);
+    CFIndex rawCount = rawList ? CFArrayGetCount(rawList) : 0;
+    CFMutableArrayRef newList = CFArrayCreateMutable(NULL, rawCount, &kCFTypeArrayCallBacks);
+
+    for (CFIndex i = 0; i < rawCount; ++i) {
+        CFStringRef uid = (CFStringRef)CFArrayGetValueAtIndex(rawList, i);
+
+        if (!uid || CFStringGetLength(uid) == 0) {
+            continue;
+        }
+
+        if (CFStringCompare(uid, CFSTR(kDevice_UID), 0) == kCFCompareEqualTo) {
+            continue;
+        }
+
+        CFArrayAppendValue(newList, uid);
+    }
+
     {
         CAMutex::Locker locker(&stateMutex);
-        
-        if (outputDeviceUID) {
-            CFRelease(outputDeviceUID);
+
+        if (outputDevicePriorityList) {
+            CFRelease(outputDevicePriorityList);
         }
-        
-        outputDeviceUID = CFStringCreateCopy(NULL, deviceUID); 
+
+        outputDevicePriorityList = newList; // takes ownership of the +1 reference
     }
-    
+
     ExecuteInAudioOutputThread(^{
         CAMutex::Locker locker(&stateMutex);
-        gPlugIn_Host->WriteToStorage(gPlugIn_Host, CFSTR("outputDeviceUID"), outputDeviceUID);
+
+        if (outputDevicePriorityList) {
+            gPlugIn_Host->WriteToStorage(gPlugIn_Host, CFSTR("outputDevicePriorityList"), outputDevicePriorityList);
+        }
     });
-    
+
     ExecuteInAudioOutputThread(^{
         setupTargetOutputDevice();
     });
+}
+
+// Serializes the stored priority list into a newline-delimited string for the
+// read channel. NB: the caller must hold stateMutex (this reads the list member).
+CFStringRef ProxyAudioDevice::copyOutputDevicePriorityListAsString() {
+    if (!outputDevicePriorityList || CFArrayGetCount(outputDevicePriorityList) == 0) {
+        return CFStringCreateCopy(NULL, CFSTR(""));
+    }
+
+    return CFStringCreateByCombiningStrings(NULL, outputDevicePriorityList, kOutputDevicePriorityListSeparator);
+}
+
+void ProxyAudioDevice::updateCurrentActiveOutputDeviceUID(AudioObjectID activeDeviceID) {
+    CFStringSmartRef uid;
+
+    if (activeDeviceID != kAudioObjectUnknown) {
+        uid = AudioDevice::copyDeviceUID(activeDeviceID);
+    }
+
+    CAMutex::Locker locker(&stateMutex);
+
+    if (outputDeviceUID) {
+        CFRelease(outputDeviceUID);
+        outputDeviceUID = NULL;
+    }
+
+    if (uid) {
+        outputDeviceUID = CFStringCreateCopy(NULL, uid);
+    }
 }
 
 UInt32 ProxyAudioDevice::retrieveOutputDeviceBufferFrameSizeFromStorage() {
@@ -5831,6 +6009,41 @@ void ProxyAudioDevice::setOutputDeviceHideWhenUnavailable(bool newHideWhenUnavai
     // re-query kAudioDevicePropertyIsHidden immediately instead of waiting for
     // the next device-availability transition.
     notifyHiddenPropertyChanged();
+}
+
+bool ProxyAudioDevice::retrieveOutputDeviceAutoFailbackFromStorage() {
+    DebugMsg("ProxyAudio: retrieveOutputDeviceAutoFailbackFromStorage");
+
+    if (!gPlugIn_Host) {
+        DebugMsg("ProxyAudio: retrieveOutputDeviceAutoFailbackFromStorage no plugin host");
+        return kOutputDeviceDefaultAutoFailback;
+    }
+
+    CFPropertyListSmartRef data;
+    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("outputDeviceAutoFailback"), &data);
+
+    if (data == NULL || CFGetTypeID(data) != CFBooleanGetTypeID()) {
+        DebugMsg("ProxyAudio: retrieveOutputDeviceAutoFailbackFromStorage finished returning default value");
+        return kOutputDeviceDefaultAutoFailback;
+    }
+
+    return CFBooleanGetValue(CFBooleanRef(CFPropertyListRef(data)));
+}
+
+void ProxyAudioDevice::setOutputDeviceAutoFailback(bool newAutoFailback) {
+    {
+        CAMutex::Locker locker(&stateMutex);
+        outputDeviceAutoFailback = newAutoFailback;
+        gPlugIn_Host->WriteToStorage(gPlugIn_Host,
+                                     CFSTR("outputDeviceAutoFailback"),
+                                     newAutoFailback ? kCFBooleanTrue : kCFBooleanFalse);
+    }
+
+    // Turning auto-failback on may mean we should immediately jump up to a
+    // higher-priority device that is currently available, so re-evaluate now.
+    ExecuteInAudioOutputThread(^{
+        setupTargetOutputDevice();
+    });
 }
 
 // Tell the host to re-read kAudioDevicePropertyIsHidden. We always notify,

--- a/proxyAudioDevice/ProxyAudioDevice.cpp
+++ b/proxyAudioDevice/ProxyAudioDevice.cpp
@@ -4619,6 +4619,17 @@ OSStatus ProxyAudioDevice::SetControlPropertyData(AudioServerPlugInDriverRef inD
                     theAnswer = kAudioHardwareUnknownPropertyError;
                     break;
             };
+            {
+                CAMutex::Locker locker(&stateMutex);
+                volumeHasBeenSet = true;
+            }
+            // Mirror the new level onto the active device's hardware volume if it
+            // has one (no-op otherwise; software attenuation covers that case).
+            // stateMutex is already released here, so this won't nest locks.
+            applyVolumeToOutputDevice();
+            // Remember this level for the active device so it is restored next
+            // time we switch to it.
+            saveVolumeForActiveDevice();
             break;
 
         case kObjectID_Mute_Output_Master:
@@ -4979,6 +4990,7 @@ void ProxyAudioDevice::setupTargetOutputDevice() {
     DebugMsg("ProxyAudio: setupTargetOutputDevice newOutputDevice: %d", newOutputDevice.id);
 
     AudioObjectID activeDeviceID = kAudioObjectUnknown;
+    bool deviceChanged = false;
     {
         CAMutex::Locker locker(outputDeviceMutex);
 
@@ -5012,7 +5024,13 @@ void ProxyAudioDevice::setupTargetOutputDevice() {
                 DebugMsg("ProxyAudio: setupTargetOutputDevice will match sample rate");
                 matchOutputDeviceSampleRateNoLock();
                 activeDeviceID = outputDevice.id;
+                deviceChanged = true;
+                // Remember whether this device can have its hardware volume
+                // driven directly; the IO proc uses this to decide whether to
+                // also attenuate in software.
+                outputDeviceHasHardwareVolume = outputDevice.hasSettableVolumeControl();
             } else {
+                outputDeviceHasHardwareVolume = false;
                 syslog(LOG_WARNING, "ProxyAudio: setupTargetOutputDevice could not find output device");
             }
         }
@@ -5022,6 +5040,155 @@ void ProxyAudioDevice::setupTargetOutputDevice() {
     // system-default fallback, or none) so the settings app can mark the active
     // row, read via ConfigType::currentActiveOutputDevice.
     updateCurrentActiveOutputDeviceUID(activeDeviceID);
+
+    // When we actually switched devices, restore the volume this device was last
+    // left at (or carry the current level over and remember it the first time).
+    if (deviceChanged) {
+        restoreVolumeForActiveDevice();
+    }
+
+    // Push the (possibly just-restored) proxy volume onto the new device's
+    // hardware volume control if it has one.
+    applyVolumeToOutputDevice();
+}
+
+void ProxyAudioDevice::applyVolumeToOutputDevice() {
+    // Snapshot the proxy's level (left channel is representative; the system sets
+    // left and right together). stateMutex is released before we take
+    // outputDeviceMutex so the two locks are never held at the same time.
+    Float32 volume;
+    bool hasBeenSet;
+    {
+        CAMutex::Locker locker(&stateMutex);
+        volume = gVolume_Output_L_Value;
+        hasBeenSet = volumeHasBeenSet;
+    }
+
+    // Don't touch a device's hardware volume until the proxy's volume has been
+    // set at least once, so we never zero out a real device on startup.
+    if (!hasBeenSet) {
+        return;
+    }
+
+    CAMutex::Locker locker(outputDeviceMutex);
+
+    if (outputDevice.isValid() && outputDeviceHasHardwareVolume.load()) {
+        outputDevice.setVolumeScalar(volume);
+    }
+}
+
+Float32 ProxyAudioDevice::retrieveVolumeForDeviceUID(CFStringRef uid) {
+    // Returns the remembered 0..1 volume for the device, or -1 if none is stored.
+    if (!gPlugIn_Host || !uid) {
+        return -1.0f;
+    }
+
+    CFPropertyListSmartRef data;
+    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("perDeviceVolume"), &data);
+
+    if (!data || CFGetTypeID(data) != CFDictionaryGetTypeID()) {
+        return -1.0f;
+    }
+
+    CFTypeRef value = CFDictionaryGetValue((CFDictionaryRef)CFPropertyListRef(data), uid);
+
+    if (!value || CFGetTypeID(value) != CFNumberGetTypeID()) {
+        return -1.0f;
+    }
+
+    Float32 volume = -1.0f;
+    CFNumberGetValue((CFNumberRef)value, kCFNumberFloat32Type, &volume);
+
+    return volume;
+}
+
+void ProxyAudioDevice::saveVolumeForDeviceUID(CFStringRef uid, Float32 volume) {
+    if (!gPlugIn_Host || !uid) {
+        return;
+    }
+
+    CFPropertyListSmartRef data;
+    gPlugIn_Host->CopyFromStorage(gPlugIn_Host, CFSTR("perDeviceVolume"), &data);
+
+    CFMutableDictionaryRef dict;
+
+    if (data && CFGetTypeID(data) == CFDictionaryGetTypeID()) {
+        dict = CFDictionaryCreateMutableCopy(NULL, 0, (CFDictionaryRef)CFPropertyListRef(data));
+    } else {
+        dict = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    }
+
+    CFNumberSmartRef number = CFNumberCreate(NULL, kCFNumberFloat32Type, &volume);
+    CFDictionarySetValue(dict, uid, number);
+    gPlugIn_Host->WriteToStorage(gPlugIn_Host, CFSTR("perDeviceVolume"), dict);
+    CFRelease(dict);
+}
+
+void ProxyAudioDevice::saveVolumeForActiveDevice() {
+    CFStringSmartRef uid;
+    Float32 volume;
+    bool hasBeenSet;
+    {
+        CAMutex::Locker locker(&stateMutex);
+        uid = outputDeviceUID ? CFStringCreateCopy(NULL, outputDeviceUID) : NULL;
+        volume = gVolume_Output_L_Value;
+        hasBeenSet = volumeHasBeenSet;
+    }
+
+    // Never persist the default-0 level we start at before the proxy is used.
+    if (!hasBeenSet || !uid) {
+        return;
+    }
+
+    saveVolumeForDeviceUID(uid, volume);
+}
+
+void ProxyAudioDevice::restoreVolumeForActiveDevice() {
+    CFStringSmartRef uid;
+    {
+        CAMutex::Locker locker(&stateMutex);
+        uid = outputDeviceUID ? CFStringCreateCopy(NULL, outputDeviceUID) : NULL;
+    }
+
+    if (!uid) {
+        return;
+    }
+
+    Float32 remembered = retrieveVolumeForDeviceUID(uid);
+
+    if (remembered < 0.0f) {
+        // First time we've seen this device: keep the current level (it carries
+        // over from the previous device) and remember it for next time.
+        saveVolumeForActiveDevice();
+        return;
+    }
+
+    {
+        CAMutex::Locker locker(&stateMutex);
+        gVolume_Output_L_Value = remembered;
+        gVolume_Output_R_Value = remembered;
+        volumeHasBeenSet = true;
+    }
+
+    // Let the system update its displayed volume to the restored level. Done
+    // outside stateMutex since the host may re-enter the driver to read it.
+    notifyVolumeChanged();
+}
+
+void ProxyAudioDevice::notifyVolumeChanged() {
+    if (!gPlugIn_Host) {
+        return;
+    }
+
+    AudioObjectPropertyAddress leftAddresses[2] = {
+        {kAudioLevelControlPropertyScalarValue, kAudioObjectPropertyScopeGlobal, 1},
+        {kAudioLevelControlPropertyDecibelValue, kAudioObjectPropertyScopeGlobal, 1}};
+    gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Volume_Output_L, 2, leftAddresses);
+
+    AudioObjectPropertyAddress rightAddresses[2] = {
+        {kAudioLevelControlPropertyScalarValue, kAudioObjectPropertyScopeGlobal, 2},
+        {kAudioLevelControlPropertyDecibelValue, kAudioObjectPropertyScopeGlobal, 2}};
+    gPlugIn_Host->PropertiesChanged(gPlugIn_Host, kObjectID_Volume_Output_R, 2, rightAddresses);
 }
 
 void ProxyAudioDevice::initializeOutputDevice() {
@@ -5520,7 +5687,15 @@ OSStatus ProxyAudioDevice::outputDeviceIOProc(AudioDeviceID inDevice,
     }
     
     Float32 volumeFactorL = 1.0, volumeFactorR = 1.0;
-    calculateVolumeFactors(currentVolumeL, currentVolumeR, currentMute, volumeFactorL, volumeFactorR);
+
+    if (outputDeviceHasHardwareVolume.load()) {
+        // The device's hardware volume is already applying the level, so don't
+        // attenuate again in software (that would double-apply it). Still honor
+        // mute here so muting is instant and works on every device.
+        calculateVolumeFactors(1.0, 1.0, currentMute, volumeFactorL, volumeFactorR);
+    } else {
+        calculateVolumeFactors(currentVolumeL, currentVolumeR, currentMute, volumeFactorL, volumeFactorR);
+    }
 
     for (UInt32 bufferIndex = 0; bufferIndex < outOutputData->mNumberBuffers; bufferIndex++) {
         UInt32 outputChannelCount = outOutputData->mBuffers[bufferIndex].mNumberChannels;

--- a/proxyAudioDevice/ProxyAudioDevice.h
+++ b/proxyAudioDevice/ProxyAudioDevice.h
@@ -135,6 +135,16 @@ class ProxyAudioDevice {
     void setOutputDeviceHideWhenUnavailable(bool newHideWhenUnavailable);
     bool retrieveOutputDeviceAutoFailbackFromStorage();
     void setOutputDeviceAutoFailback(bool newAutoFailback);
+    // Pushes the proxy's current volume onto the active output device's hardware
+    // volume control, if that device has one (see outputDeviceHasHardwareVolume).
+    void applyVolumeToOutputDevice();
+    // Per-device volume memory: each device's last-used level is remembered by UID
+    // so switching to a device restores the volume it was last left at.
+    Float32 retrieveVolumeForDeviceUID(CFStringRef uid);
+    void saveVolumeForDeviceUID(CFStringRef uid, Float32 volume);
+    void saveVolumeForActiveDevice();
+    void restoreVolumeForActiveDevice();
+    void notifyVolumeChanged();
     void notifyHiddenPropertyChanged();
 
     static ProxyAudioDevice *deviceForDriver(void *inDriver);
@@ -567,6 +577,16 @@ class ProxyAudioDevice {
     Float32 gVolume_Output_L_Value = 0.0;
     Float32 gVolume_Output_R_Value = 0.0;
     bool gMute_Output_Mute = false;
+    // True when the active output device exposes a settable hardware volume, in
+    // which case the proxy drives that directly and the IO proc skips software
+    // attenuation (mute is still applied in software). Read from the realtime IO
+    // proc, so it's atomic.
+    std::atomic_bool outputDeviceHasHardwareVolume{false};
+    // The proxy's volume defaults to 0 and is only set once the system/user
+    // adjusts it (which happens when the proxy is selected as output). We don't
+    // push to a device's hardware volume until then, so we never zero a device's
+    // real hardware volume on startup. Guarded by stateMutex.
+    bool volumeHasBeenSet = false;
     const UInt32 gDevice_BytesPerFrameInChannel = 4;
     const UInt32 gDevice_ChannelsPerFrame = 2;
     const UInt32 gDevice_SafetyOffset = 0;

--- a/proxyAudioDevice/ProxyAudioDevice.h
+++ b/proxyAudioDevice/ProxyAudioDevice.h
@@ -32,21 +32,42 @@ enum {
 // Default to false so the proxy device stays visible even when the target is
 // unavailable. This preserves the long-standing behavior for existing users.
 #define kOutputDeviceDefaultHideWhenUnavailable false
+// Default to true: when a higher-priority device in the chain becomes available
+// again, automatically switch back up to it. Users who prefer to avoid
+// mid-playback interruptions can turn this off (sticky behavior).
+#define kOutputDeviceDefaultAutoFailback true
+// Separator used to serialize the ordered priority list of device UIDs into a
+// single string for the configuration channel. Device UIDs never contain a
+// newline, so it is a safe delimiter.
+#define kOutputDevicePriorityListSeparator CFSTR("\n")
 
 class ProxyAudioDevice {
   public:
     enum class ConfigType {
         none,
-        outputDevice,
+        outputDevicePriorityList,
         outputDeviceBufferFrameSize,
         deviceName,
         deviceActiveCondition,
-        deviceHideWhenUnavailable
+        deviceHideWhenUnavailable,
+        outputDeviceAutoFailback,
+        // Read-only: the UID of the device the driver is currently routing audio
+        // to (a chain entry or the system-default fallback). Used by the settings
+        // app to mark the active row. Empty string when nothing is available.
+        currentActiveOutputDevice
     };
     enum class ActiveCondition { proxiedDeviceActive = 0, userActive = 1, always = 2 };
 
     ProxyAudioDevice() : inputIOIsActive(false) {};
-    AudioDevice findTargetOutputAudioDevice();
+    // Resolves the device that should currently be active by walking the priority
+    // chain. currentActiveUID is the UID of the device presently in use (or NULL),
+    // used to honor sticky behavior when auto-failback is disabled.
+    AudioDevice findTargetOutputAudioDevice(CFStringRef currentActiveUID);
+    // Pure selection step: returns a newly-retained UID (+1, caller releases) of
+    // the device that should be active given the chain, current availability, the
+    // auto-failback setting, and the currently-active device. Returns NULL when
+    // neither any listed device nor the system-default fallback is available.
+    CFStringRef copyChosenTargetDeviceUID(CFStringRef currentActiveUID);
     static int outputDeviceAliveListenerStatic(AudioObjectID inObjectID,
                                                UInt32 inNumberAddresses,
                                                const AudioObjectPropertyAddress *inAddresses,
@@ -102,14 +123,18 @@ class ProxyAudioDevice {
     CFStringRef copyDeviceNameFromStorage();
     void setDeviceName(CFStringRef newName);
     CFStringRef copyDefaultProxyOutputDeviceUID();
-    CFStringRef copyOutputDeviceUIDFromStorage();
-    void setOutputDevice(CFStringRef deviceUID);
+    CFArrayRef copyOutputDevicePriorityListFromStorage();
+    void setOutputDevicePriorityList(CFStringRef newlineDelimitedUIDs);
+    CFStringRef copyOutputDevicePriorityListAsString();
+    void updateCurrentActiveOutputDeviceUID(AudioObjectID activeDeviceID);
     UInt32 retrieveOutputDeviceBufferFrameSizeFromStorage();
     void setOutputDeviceBufferFrameSize(UInt32 size);
     ActiveCondition retrieveOutputDeviceActiveConditionFromStorage();
     void setOutputDeviceActiveCondition(ActiveCondition newActiveCondition);
     bool retrieveOutputDeviceHideWhenUnavailableFromStorage();
     void setOutputDeviceHideWhenUnavailable(bool newHideWhenUnavailable);
+    bool retrieveOutputDeviceAutoFailbackFromStorage();
+    void setOutputDeviceAutoFailback(bool newAutoFailback);
     void notifyHiddenPropertyChanged();
 
     static ProxyAudioDevice *deviceForDriver(void *inDriver);
@@ -504,6 +529,14 @@ class ProxyAudioDevice {
     pid_t configuratorPid = 0;
     CFStringRef deviceName = NULL;
     CFStringRef boxName = NULL;
+    // Ordered list of candidate output device UIDs, highest priority first.
+    // The driver routes audio to the highest-priority entry that is currently
+    // available, falling back to the system default when none are. Guarded by
+    // stateMutex.
+    CFArrayRef outputDevicePriorityList = NULL;
+    // The UID of the device audio is actually being routed to right now (a chain
+    // entry or the fallback), reported to the settings app so it can mark the
+    // active row. NULL when nothing is available. Guarded by stateMutex.
     CFStringRef outputDeviceUID = NULL;
     UInt32 outputDeviceBufferFrameSize = kOutputDeviceDefaultBufferFrameSize;
     SInt64 smallestFramesToBufferEnd = -1;
@@ -511,6 +544,10 @@ class ProxyAudioDevice {
     UInt64 outputAccumulatedRateRatioSamples = 0;
     ActiveCondition outputDeviceActiveCondition = ActiveCondition::userActive;
     bool outputDeviceHideWhenUnavailable = kOutputDeviceDefaultHideWhenUnavailable;
+    // When true, automatically switch back up to a higher-priority device as soon
+    // as it becomes available; when false, stay on the current device until it
+    // becomes unavailable (sticky). Guarded by stateMutex.
+    bool outputDeviceAutoFailback = kOutputDeviceDefaultAutoFailback;
     
     UInt32 gPlugIn_RefCount = 0;
     AudioServerPlugInHostRef gPlugIn_Host = NULL;

--- a/shared/AudioDevice.cpp
+++ b/shared/AudioDevice.cpp
@@ -170,6 +170,68 @@ void AudioDevice::setBufferFrameSize(UInt32 newBufferFrameSize) {
     }
 }
 
+bool AudioDevice::hasSettableVolumeControl() {
+    if (id == kAudioObjectUnknown) {
+        return false;
+    }
+
+    // Prefer the master element, then fall back to the left/right channels. A
+    // device "has volume control" if any of these is present and settable.
+    AudioObjectPropertyElement elements[] = {kAudioObjectPropertyElementMaster, 1, 2};
+
+    for (AudioObjectPropertyElement element : elements) {
+        AudioObjectPropertyAddress address = {
+            kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, element};
+
+        if (!AudioObjectHasProperty(id, &address)) {
+            continue;
+        }
+
+        Boolean settable = false;
+
+        if (AudioObjectIsPropertySettable(id, &address, &settable) == noErr && settable) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void AudioDevice::setVolumeScalar(Float32 volume) {
+    if (id == kAudioObjectUnknown) {
+        return;
+    }
+
+    if (volume < 0.0f) {
+        volume = 0.0f;
+    } else if (volume > 1.0f) {
+        volume = 1.0f;
+    }
+
+    // If the master element is settable, set that and we're done. Otherwise apply
+    // the same value to whichever of the left/right channels are settable.
+    AudioObjectPropertyAddress masterAddress = {
+        kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, kAudioObjectPropertyElementMaster};
+    Boolean settable = false;
+
+    if (AudioObjectHasProperty(id, &masterAddress)
+        && AudioObjectIsPropertySettable(id, &masterAddress, &settable) == noErr && settable) {
+        AudioObjectSetPropertyData(id, &masterAddress, 0, NULL, sizeof(volume), &volume);
+        return;
+    }
+
+    for (AudioObjectPropertyElement element : {(AudioObjectPropertyElement)1, (AudioObjectPropertyElement)2}) {
+        AudioObjectPropertyAddress channelAddress = {
+            kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, element};
+        settable = false;
+
+        if (AudioObjectHasProperty(id, &channelAddress)
+            && AudioObjectIsPropertySettable(id, &channelAddress, &settable) == noErr && settable) {
+            AudioObjectSetPropertyData(id, &channelAddress, 0, NULL, sizeof(volume), &volume);
+        }
+    }
+}
+
 void AudioDevice::setupIOProc(AudioDeviceIOProc inProc, void *clientData) {
     if (!isValid()) {
         syslog(LOG_WARNING,

--- a/shared/AudioDevice.h
+++ b/shared/AudioDevice.h
@@ -25,6 +25,12 @@ class AudioDevice {
                                    AudioObjectPropertyScope scope,
                                    AudioObjectPropertyElement element);
     void setBufferFrameSize(UInt32 bufferFrameSize);
+    // Returns true if this device exposes a settable output volume (master or
+    // per-channel), i.e. its hardware/driver volume can be controlled.
+    bool hasSettableVolumeControl();
+    // Sets the device's output volume (0..1 scalar) on whichever element is
+    // settable: master if available, otherwise the left/right channels.
+    void setVolumeScalar(Float32 volume);
     void setupIOProc(AudioDeviceIOProc inProc, void *clientData);
     void destroyIOProc();
     void start();


### PR DESCRIPTION
## Summary

Adds a **device priority chain** to the Proxy Audio Device. Instead of proxying to a single fixed output device, you configure an ordered list of devices and the driver automatically routes audio to the highest-priority one that is currently available — falling through to the next when a device disconnects, and (optionally) switching back up when a higher-priority device returns.

It also makes volume smarter: the proxy now drives the **target device's own hardware volume** when it has one, and **remembers each device's volume** so switching restores the level you last used.

This is useful when you regularly move between outputs (e.g. a USB DAC / audio interface at your desk, Bluetooth headphones, and the built-in speakers as a last resort) and want the proxy to "just follow" your preferred device without manual reconfiguration.

## Behavior

### Priority chain
- The proxy routes to the **highest-priority device that is present *and* alive**.
- When the active device is removed or goes not-alive, it **advances down the chain** immediately.
- **Automatically switch back to higher-priority devices** (checkbox, on by default): when a higher-priority device returns, switch back up to it. Turn it off for "sticky" behavior — stay on the current device until it too becomes unavailable.
- When **no** listed device is available, it falls back to the current **system default output device** (excluding the proxy itself), so audio is never silently dropped. This fallback is never sticky — as soon as any listed device returns, the proxy switches to it.
- Existing `hide when unavailable` still works; with the fallback in place it now only triggers when there is no output device available at all.

### Volume
- If the active device exposes a **settable hardware volume**, the proxy drives that directly, so the system volume keys change the real device's volume. Devices without hardware volume keep using the existing **software** attenuation. Software gain is bypassed whenever hardware volume is in use, so the signal is never attenuated twice.
- **Per-device volume memory:** each device's level is remembered by UID. Switching to a device (including via automatic failover) restores the volume it was last left at and updates the system volume display. The first time a device is seen, the current level carries over and is then remembered.
- Mute is always applied in software so it works regardless of the device.

## Implementation

**Driver (`proxyAudioDevice/`)**
- The single stored output-device UID becomes an ordered chain of UIDs — a `CFArray` in plugin-host storage, serialized newline-delimited over the existing identify/name configuration channel.
- New selection step walks the chain, picks the highest-priority present-and-alive device, honors the auto-failback/sticky setting among listed devices, and falls back to the system default otherwise.
- The per-device `kAudioDevicePropertyDeviceIsAlive` listener now re-evaluates the chain immediately (a dying device does not always disappear from the device list, so we can't rely solely on the device-list listener).
- Volume: `AudioDevice` gains `hasSettableVolumeControl()` / `setVolumeScalar()`; the IO proc bypasses software gain when hardware volume is active; per-device levels are stored as a UID→volume dictionary in plugin-host storage and restored on each device switch.
- New `ConfigType`s: `outputDevicePriorityList`, `outputDeviceAutoFailback`, and read-only `currentActiveOutputDevice` (so the settings app can mark the active row).

**Settings app (`ProxyAudioDeviceSettings/`)**
- The output-device combo box is replaced with an editable, ordered list (`NSTableView`) plus add / remove / move-up / move-down controls and the auto-failback checkbox (built programmatically).
- Each row shows its status (Available / Unavailable / ● Active) using the same present-and-alive test as the driver.
- Display names are cached in the app's own preferences, so devices that are currently disconnected still show a friendly name instead of a raw UID.
- The list refreshes on device-change notifications and via a light poll, but only redraws when the displayed data actually changes, so the table keeps its selection/focus while you reorder.

## Notes for the maintainer

- **Deployment target raised to macOS 14.6.** The project no longer builds against the 10.11 SDK on current Xcode, so I bumped it to get a clean build. The new code itself doesn't require a floor this high — please lower it to whatever you can actually test/support. I don't have a setup to verify older macOS versions.
- **No migration:** existing users' previously-selected single device is not carried over into the new chain; they'll pick their devices once after updating. Happy to add a one-line fallback that seeds the chain from the old `outputDeviceUID` storage key if you'd prefer.
- Tested locally: ad-hoc-signed build installed to `/Library/Audio/Plug-Ins/HAL`, verified failover down, failback up, the system-default fallback, hardware + software volume, per-device volume restore, and the live status/active updates by connecting/disconnecting real devices.

## Screenshot

<img width="623" height="628" alt="Proxy Audio Device Settings 2026-06-29 14 48 24" src="https://github.com/user-attachments/assets/0a7b9aa6-c9d6-43f8-bb94-fdac2f826335" />
